### PR TITLE
Define normalized data models

### DIFF
--- a/src/reddit_digest/models/__init__.py
+++ b/src/reddit_digest/models/__init__.py
@@ -1,1 +1,7 @@
 """Data models."""
+
+from reddit_digest.models.comment import Comment
+from reddit_digest.models.digest import DigestItem
+from reddit_digest.models.post import Post
+
+__all__ = ["Comment", "DigestItem", "Post"]

--- a/src/reddit_digest/models/base.py
+++ b/src/reddit_digest/models/base.py
@@ -1,0 +1,62 @@
+"""Shared model helpers."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from dataclasses import dataclass
+from typing import Any
+
+
+class ModelError(ValueError):
+    """Raised when raw data cannot be normalized into a typed model."""
+
+
+@dataclass(frozen=True)
+class BaseModel:
+    """Base class for typed models with simple serialization support."""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def require_string(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ModelError(f"'{key}' must be a non-empty string")
+    return value.strip()
+
+
+def optional_string(payload: dict[str, Any], key: str) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ModelError(f"'{key}' must be a string when provided")
+    stripped = value.strip()
+    return stripped or None
+
+
+def require_int(payload: dict[str, Any], key: str) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int):
+        raise ModelError(f"'{key}' must be an integer")
+    return value
+
+
+def require_non_negative_int(payload: dict[str, Any], key: str) -> int:
+    value = require_int(payload, key)
+    if value < 0:
+        raise ModelError(f"'{key}' must be greater than or equal to 0")
+    return value
+
+
+def require_string_list(payload: dict[str, Any], key: str) -> tuple[str, ...]:
+    value = payload.get(key)
+    if not isinstance(value, list) or not value:
+        raise ModelError(f"'{key}' must be a non-empty list")
+    items: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise ModelError(f"'{key}' entries must be non-empty strings")
+        items.append(item.strip())
+    return tuple(items)

--- a/src/reddit_digest/models/comment.py
+++ b/src/reddit_digest/models/comment.py
@@ -1,0 +1,47 @@
+"""Normalized Reddit comment model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from reddit_digest.models.base import BaseModel
+from reddit_digest.models.base import ModelError
+from reddit_digest.models.base import optional_string
+from reddit_digest.models.base import require_int
+from reddit_digest.models.base import require_non_negative_int
+from reddit_digest.models.base import require_string
+
+
+@dataclass(frozen=True)
+class Comment(BaseModel):
+    id: str
+    post_id: str
+    parent_id: str
+    subreddit: str
+    author: str | None
+    body: str
+    score: int
+    created_utc: int
+    permalink: str
+
+    @classmethod
+    def from_raw(cls, payload: dict[str, Any]) -> "Comment":
+        body = require_string(payload, "body")
+        if body in {"[deleted]", "[removed]"}:
+            raise ModelError("'body' must contain comment text")
+        return cls(
+            id=require_string(payload, "id"),
+            post_id=require_string(payload, "post_id"),
+            parent_id=require_string(payload, "parent_id"),
+            subreddit=require_string(payload, "subreddit"),
+            author=optional_string(payload, "author"),
+            body=body,
+            score=require_int(payload, "score"),
+            created_utc=require_non_negative_int(payload, "created_utc"),
+            permalink=require_string(payload, "permalink"),
+        )
+
+    def __post_init__(self) -> None:
+        if not self.permalink.startswith("/r/"):
+            raise ModelError("'permalink' must start with '/r/'")

--- a/src/reddit_digest/models/digest.py
+++ b/src/reddit_digest/models/digest.py
@@ -1,0 +1,51 @@
+"""Typed digest item model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from reddit_digest.models.base import BaseModel
+from reddit_digest.models.base import ModelError
+from reddit_digest.models.base import optional_string
+from reddit_digest.models.base import require_string
+from reddit_digest.models.base import require_string_list
+
+
+@dataclass(frozen=True)
+class DigestItem(BaseModel):
+    category: str
+    title: str
+    subreddit: str
+    permalink: str
+    why_it_matters: str
+    impact_score: float
+    tags: tuple[str, ...]
+    source_post_ids: tuple[str, ...]
+    evidence: str | None = None
+
+    @classmethod
+    def from_raw(cls, payload: dict[str, Any]) -> "DigestItem":
+        impact_score = payload.get("impact_score")
+        if not isinstance(impact_score, (int, float)):
+            raise ModelError("'impact_score' must be numeric")
+
+        item = cls(
+            category=require_string(payload, "category"),
+            title=require_string(payload, "title"),
+            subreddit=require_string(payload, "subreddit"),
+            permalink=require_string(payload, "permalink"),
+            why_it_matters=require_string(payload, "why_it_matters"),
+            impact_score=float(impact_score),
+            tags=require_string_list(payload, "tags"),
+            source_post_ids=require_string_list(payload, "source_post_ids"),
+            evidence=optional_string(payload, "evidence"),
+        )
+
+        if item.impact_score < 0:
+            raise ModelError("'impact_score' must be greater than or equal to 0")
+        return item
+
+    def __post_init__(self) -> None:
+        if not self.permalink.startswith("http"):
+            raise ModelError("'permalink' must be an absolute URL")

--- a/src/reddit_digest/models/post.py
+++ b/src/reddit_digest/models/post.py
@@ -1,0 +1,47 @@
+"""Normalized Reddit post model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from reddit_digest.models.base import BaseModel
+from reddit_digest.models.base import ModelError
+from reddit_digest.models.base import optional_string
+from reddit_digest.models.base import require_int
+from reddit_digest.models.base import require_non_negative_int
+from reddit_digest.models.base import require_string
+
+
+@dataclass(frozen=True)
+class Post(BaseModel):
+    id: str
+    subreddit: str
+    title: str
+    author: str | None
+    score: int
+    num_comments: int
+    created_utc: int
+    url: str
+    permalink: str
+    selftext: str | None
+
+    @classmethod
+    def from_raw(cls, payload: dict[str, Any]) -> "Post":
+        created_utc = require_non_negative_int(payload, "created_utc")
+        return cls(
+            id=require_string(payload, "id"),
+            subreddit=require_string(payload, "subreddit"),
+            title=require_string(payload, "title"),
+            author=optional_string(payload, "author"),
+            score=require_int(payload, "score"),
+            num_comments=require_non_negative_int(payload, "num_comments"),
+            created_utc=created_utc,
+            url=require_string(payload, "url"),
+            permalink=require_string(payload, "permalink"),
+            selftext=optional_string(payload, "selftext"),
+        )
+
+    def __post_init__(self) -> None:
+        if not self.permalink.startswith("/r/"):
+            raise ModelError("'permalink' must start with '/r/'")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from reddit_digest.models.base import ModelError
+from reddit_digest.models.comment import Comment
+from reddit_digest.models.digest import DigestItem
+from reddit_digest.models.post import Post
+
+
+def test_post_from_raw_normalizes_fixture(sample_posts_payload: list[dict[str, Any]]) -> None:
+    post = Post.from_raw(sample_posts_payload[0])
+
+    assert post.id == "post_001"
+    assert post.subreddit == "Codex"
+    assert post.num_comments == 18
+    assert post.to_dict()["title"] == "Codex agent keeps a local context file for every task"
+
+
+def test_comment_from_raw_normalizes_fixture(sample_comments_payload: list[dict[str, Any]]) -> None:
+    comment = Comment.from_raw(sample_comments_payload[0])
+
+    assert comment.post_id == "post_001"
+    assert comment.parent_id == "t3_post_001"
+    assert "deterministic" in comment.body
+
+
+def test_deleted_comment_is_rejected(sample_comments_payload: list[dict[str, Any]]) -> None:
+    deleted_comment = dict(sample_comments_payload[0])
+    deleted_comment["body"] = "[deleted]"
+
+    with pytest.raises(ModelError, match="comment text"):
+        Comment.from_raw(deleted_comment)
+
+
+def test_digest_item_from_raw_validates_required_fields() -> None:
+    payload = {
+        "category": "tools",
+        "title": "Codex",
+        "subreddit": "Codex",
+        "permalink": "https://reddit.com/r/Codex/comments/post_001",
+        "why_it_matters": "Helps automate repo changes with clear task context.",
+        "impact_score": 8.7,
+        "tags": ["ai-agents", "tooling"],
+        "source_post_ids": ["post_001"],
+        "evidence": "Mentioned repeatedly in the thread and comments.",
+    }
+
+    item = DigestItem.from_raw(payload)
+
+    assert item.category == "tools"
+    assert item.tags == ("ai-agents", "tooling")
+    assert item.source_post_ids == ("post_001",)
+
+
+def test_post_requires_relative_permalink(sample_posts_payload: list[dict[str, Any]]) -> None:
+    invalid_post = dict(sample_posts_payload[0])
+    invalid_post["permalink"] = "https://reddit.com/r/Codex/comments/post_001"
+
+    with pytest.raises(ModelError, match="permalink"):
+        Post.from_raw(invalid_post)
+
+
+def test_negative_scores_are_preserved(sample_posts_payload: list[dict[str, Any]]) -> None:
+    post_payload = dict(sample_posts_payload[0])
+    post_payload["score"] = -3
+
+    comment_payload = {
+        "id": "comment_negative_score",
+        "post_id": "post_001",
+        "parent_id": "t3_post_001",
+        "subreddit": "Codex",
+        "author": "skeptic",
+        "body": "This still has useful schema even when the score is negative.",
+        "score": -1,
+        "created_utc": 1773316500,
+        "permalink": "/r/Codex/comments/post_001/comment_negative_score/",
+    }
+
+    assert Post.from_raw(post_payload).score == -3
+    assert Comment.from_raw(comment_payload).score == -1


### PR DESCRIPTION
## Summary
- add typed post, comment, and digest item models
- add raw payload normalization helpers with explicit validation
- cover model behavior and invalid inputs with tests

Closes #5

## Testing
- uv run pytest
- uv run python -m compileall src tests