### PR TITLE
Implement Reddit comment collector

### DIFF
--- a/src/reddit_digest/collectors/reddit_comments.py
+++ b/src/reddit_digest/collectors/reddit_comments.py
@@ -1,0 +1,116 @@
+"""Reddit comment collection and persistence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC
+from datetime import datetime
+from pathlib import Path
+import json
+from typing import Any
+from typing import Protocol
+
+from praw.models import Submission
+
+from reddit_digest.models.comment import Comment
+from reddit_digest.models.post import Post
+
+
+class RedditCommentSource(Protocol):
+    """Interface for fetching raw comments for a post."""
+
+    def fetch_comments(self, post: Post, limit: int) -> list[dict[str, Any]]:
+        """Return raw comment payloads for a post."""
+
+
+@dataclass(frozen=True)
+class CollectedComments:
+    run_date: str
+    raw_path: Path
+    processed_path: Path
+    comments: tuple[Comment, ...]
+
+
+class PrawRedditCommentSource:
+    """Live Reddit comment source backed by PRAW submissions."""
+
+    def __init__(self, submission_loader: callable[[str], Submission]) -> None:
+        self._submission_loader = submission_loader
+
+    def fetch_comments(self, post: Post, limit: int) -> list[dict[str, Any]]:
+        submission = self._submission_loader(post.id)
+        submission.comments.replace_more(limit=0)
+        serialized: list[dict[str, Any]] = []
+        for comment in submission.comments.list():
+            serialized.append(
+                {
+                    "id": comment.id,
+                    "post_id": post.id,
+                    "parent_id": comment.parent_id,
+                    "subreddit": post.subreddit,
+                    "author": None if comment.author is None else str(comment.author),
+                    "body": comment.body,
+                    "score": comment.score,
+                    "created_utc": int(comment.created_utc),
+                    "permalink": comment.permalink,
+                }
+            )
+            if len(serialized) >= limit:
+                break
+        return serialized
+
+
+class CommentCollector:
+    """Collect, normalize, and persist comments for shortlisted posts."""
+
+    def __init__(self, source: RedditCommentSource, raw_root: Path, processed_root: Path) -> None:
+        self._source = source
+        self._raw_root = raw_root
+        self._processed_root = processed_root
+
+    def collect(
+        self,
+        posts: tuple[Post, ...],
+        *,
+        max_comments_per_post: int,
+        run_at: datetime | None = None,
+    ) -> CollectedComments:
+        current_time = run_at or datetime.now(tz=UTC)
+        run_date = current_time.date().isoformat()
+        raw_payload: dict[str, list[dict[str, Any]]] = {}
+        normalized_comments: list[Comment] = []
+
+        for post in posts:
+            raw_comments = self._source.fetch_comments(post, max_comments_per_post)
+            raw_payload[post.id] = raw_comments
+            normalized_comments.extend(
+                self._normalize_comments(raw_comments, max_comments_per_post=max_comments_per_post)
+            )
+
+        raw_path = self._write_json(self._raw_root / "comments" / f"{run_date}.json", raw_payload)
+        processed_path = self._write_json(
+            self._processed_root / "comments" / f"{run_date}.json",
+            [comment.to_dict() for comment in normalized_comments],
+        )
+        return CollectedComments(
+            run_date=run_date,
+            raw_path=raw_path,
+            processed_path=processed_path,
+            comments=tuple(normalized_comments),
+        )
+
+    def _normalize_comments(self, payloads: list[dict[str, Any]], *, max_comments_per_post: int) -> list[Comment]:
+        normalized: list[Comment] = []
+        for item in sorted(payloads, key=lambda payload: (payload.get("created_utc", 0), payload.get("id", ""))):
+            body = item.get("body")
+            if not isinstance(body, str) or not body.strip() or body.strip() in {"[deleted]", "[removed]"}:
+                continue
+            normalized.append(Comment.from_raw(item))
+            if len(normalized) >= max_comments_per_post:
+                break
+        return normalized
+
+    def _write_json(self, path: Path, payload: Any) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+        return path

--- a/tests/test_reddit_comments.py
+++ b/tests/test_reddit_comments.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import UTC
+from datetime import datetime
+from pathlib import Path
+import json
+from typing import Any
+
+from reddit_digest.collectors.reddit_comments import CommentCollector
+from reddit_digest.models.post import Post
+
+
+class StubCommentSource:
+    def __init__(self, payloads: dict[str, list[dict[str, Any]]]) -> None:
+        self.payloads = payloads
+
+    def fetch_comments(self, post: Post, limit: int) -> list[dict[str, Any]]:
+        return self.payloads.get(post.id, [])[:limit]
+
+
+def sample_posts(sample_posts_payload: list[dict[str, Any]]) -> tuple[Post, ...]:
+    return tuple(Post.from_raw(item) for item in sample_posts_payload)
+
+
+def test_collect_comments_filters_deleted_and_persists(
+    sample_posts_payload: list[dict[str, Any]],
+    sample_comments_payload: list[dict[str, Any]],
+    tmp_path: Path,
+) -> None:
+    deleted_comment = dict(sample_comments_payload[0])
+    deleted_comment["id"] = "comment_deleted"
+    deleted_comment["body"] = "[deleted]"
+
+    collector = CommentCollector(
+        StubCommentSource(
+            {
+                "post_001": [sample_comments_payload[0], deleted_comment],
+                "post_002": [sample_comments_payload[1]],
+            }
+        ),
+        tmp_path / "raw",
+        tmp_path / "processed",
+    )
+
+    result = collector.collect(
+        sample_posts(sample_posts_payload),
+        max_comments_per_post=5,
+        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+    )
+
+    assert [comment.id for comment in result.comments] == ["comment_001", "comment_002"]
+    assert json.loads(result.raw_path.read_text())["post_001"][1]["id"] == "comment_deleted"
+    assert len(json.loads(result.processed_path.read_text())) == 2
+
+
+def test_collect_comments_respects_max_per_post(
+    sample_posts_payload: list[dict[str, Any]],
+    sample_comments_payload: list[dict[str, Any]],
+    tmp_path: Path,
+) -> None:
+    comments: list[dict[str, Any]] = []
+    for index in range(4):
+        comment = dict(sample_comments_payload[0])
+        comment["id"] = f"comment_{index}"
+        comment["created_utc"] = 1773316500 + index
+        comments.append(comment)
+
+    collector = CommentCollector(
+        StubCommentSource({"post_001": comments, "post_002": []}),
+        tmp_path / "raw",
+        tmp_path / "processed",
+    )
+
+    result = collector.collect(
+        sample_posts(sample_posts_payload),
+        max_comments_per_post=2,
+        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+    )
+
+    assert [comment.id for comment in result.comments] == ["comment_0", "comment_1"]
+
+
+def test_collect_comments_handles_empty_results(sample_posts_payload: list[dict[str, Any]], tmp_path: Path) -> None:
+    collector = CommentCollector(StubCommentSource({}), tmp_path / "raw", tmp_path / "processed")
+
+    result = collector.collect(
+        sample_posts(sample_posts_payload),
+        max_comments_per_post=2,
+        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+    )
+
+    assert result.comments == ()
+    assert json.loads(result.processed_path.read_text()) == []


### PR DESCRIPTION
## Summary
- add a replaceable Reddit comment source interface and submission-backed implementation
- collect, normalize, and persist dated raw and processed comment payloads
- cover deleted comments, max-comment limits, and empty results with tests

Closes #4

## Testing
- uv run pytest tests/test_reddit_comments.py tests/test_reddit_posts.py tests/test_models.py tests/test_config.py
- uv run python -m compileall src tests