### PR TITLE
Add optional secondary subreddit support

### DIFF
--- a/src/reddit_digest/collectors/reddit_posts.py
+++ b/src/reddit_digest/collectors/reddit_posts.py
@@ -99,7 +99,7 @@ class PostCollector:
 
     def _fetch_and_filter(self, config: SubredditConfig, *, minimum_created_utc: int) -> dict[str, Any]:
         by_subreddit: dict[str, Any] = {}
-        for subreddit in config.primary:
+        for subreddit in config.enabled_subreddits:
             deduped: dict[str, dict[str, Any]] = {}
             raw_by_mode: dict[str, list[dict[str, Any]]] = {}
             for sort_mode in config.fetch.sort_modes:

--- a/tests/test_reddit_posts.py
+++ b/tests/test_reddit_posts.py
@@ -35,6 +35,22 @@ def build_config() -> SubredditConfig:
     )
 
 
+def build_config_with_secondary(*, include_secondary: bool) -> SubredditConfig:
+    return SubredditConfig(
+        primary=("Codex",),
+        secondary=("LocalLLaMA",),
+        include_secondary=include_secondary,
+        fetch=FetchConfig(
+            lookback_hours=24,
+            sort_modes=("new",),
+            min_post_score=5,
+            min_comments=3,
+            max_posts_per_subreddit=2,
+            max_comments_per_post=50,
+        ),
+    )
+
+
 def test_collect_posts_filters_and_persists(sample_posts_payload: list[dict[str, Any]], tmp_path: Path) -> None:
     old_post = dict(sample_posts_payload[0])
     old_post["id"] = "post_old"
@@ -102,3 +118,57 @@ def test_collect_posts_respects_max_posts_per_subreddit(sample_posts_payload: li
     )
 
     assert [post.id for post in result.posts] == ["codex_0", "codex_1"]
+
+
+def test_collect_posts_excludes_secondary_subreddits_by_default(
+    sample_posts_payload: list[dict[str, Any]],
+    tmp_path: Path,
+) -> None:
+    local_payload = dict(sample_posts_payload[0])
+    local_payload["id"] = "local_001"
+    local_payload["subreddit"] = "LocalLLaMA"
+
+    collector = PostCollector(
+        StubPostSource(
+            {
+                ("Codex", "new"): [sample_posts_payload[0]],
+                ("LocalLLaMA", "new"): [local_payload],
+            }
+        ),
+        tmp_path / "raw",
+        tmp_path / "processed",
+    )
+
+    result = collector.collect(
+        build_config_with_secondary(include_secondary=False),
+        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+    )
+
+    assert [post.id for post in result.posts] == ["post_001"]
+
+
+def test_collect_posts_can_include_secondary_subreddits(
+    sample_posts_payload: list[dict[str, Any]],
+    tmp_path: Path,
+) -> None:
+    local_payload = dict(sample_posts_payload[0])
+    local_payload["id"] = "local_001"
+    local_payload["subreddit"] = "LocalLLaMA"
+
+    collector = PostCollector(
+        StubPostSource(
+            {
+                ("Codex", "new"): [sample_posts_payload[0]],
+                ("LocalLLaMA", "new"): [local_payload],
+            }
+        ),
+        tmp_path / "raw",
+        tmp_path / "processed",
+    )
+
+    result = collector.collect(
+        build_config_with_secondary(include_secondary=True),
+        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+    )
+
+    assert [post.subreddit for post in result.posts] == ["Codex", "LocalLLaMA"]


### PR DESCRIPTION
## Summary
- switch post collection to the config-driven enabled subreddit set
- keep primary-only collection as the default behavior
- add tests covering both primary-only and primary-plus-secondary runs

Closes #14

## Testing
- uv run pytest tests/test_reddit_posts.py tests/test_config.py