### PR TITLE
Build extraction layer for tools, approaches, guides, and testing insights

### DIFF
--- a/src/reddit_digest/extractors/approaches.py
+++ b/src/reddit_digest/extractors/approaches.py
@@ -1,0 +1,27 @@
+"""Workflow and approach extraction rules."""
+
+from __future__ import annotations
+
+import re
+
+from reddit_digest.extractors.common import InsightPattern
+
+
+APPROACH_PATTERNS: tuple[InsightPattern, ...] = (
+    InsightPattern(
+        title="Test-first refactors",
+        category="approaches",
+        summary="Authors are using tests or fixtures before asking agents to change production code.",
+        why_it_matters="This makes AI-assisted changes safer and easier to verify.",
+        tags=("ai-dev-workflow", "ai-testing", "reliability"),
+        regex=re.compile(r"test-first|fixtures before|before asking the model"),
+    ),
+    InsightPattern(
+        title="Context snapshots",
+        category="approaches",
+        summary="Teams are capturing local context snapshots before each AI-assisted change.",
+        why_it_matters="Stable context helps with recovery and reduces drift across iterations.",
+        tags=("ai-dev-workflow", "coding-agents", "prompting"),
+        regex=re.compile(r"context file|snapshot the repo state|context snapshots?"),
+    ),
+)

--- a/src/reddit_digest/extractors/common.py
+++ b/src/reddit_digest/extractors/common.py
@@ -1,0 +1,77 @@
+"""Shared extraction helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+from reddit_digest.models.comment import Comment
+from reddit_digest.models.insight import Insight
+from reddit_digest.models.post import Post
+
+
+@dataclass(frozen=True)
+class TextSource:
+    source_kind: str
+    source_id: str
+    source_post_id: str
+    subreddit: str
+    permalink: str
+    text: str
+
+
+@dataclass(frozen=True)
+class InsightPattern:
+    title: str
+    category: str
+    summary: str
+    why_it_matters: str
+    tags: tuple[str, ...]
+    regex: re.Pattern[str]
+
+
+def post_source(post: Post) -> TextSource:
+    text = "\n".join(part for part in [post.title, post.selftext or ""] if part)
+    return TextSource(
+        source_kind="post",
+        source_id=post.id,
+        source_post_id=post.id,
+        subreddit=post.subreddit,
+        permalink=post.url,
+        text=text,
+    )
+
+
+def comment_source(comment: Comment) -> TextSource:
+    return TextSource(
+        source_kind="comment",
+        source_id=comment.id,
+        source_post_id=comment.post_id,
+        subreddit=comment.subreddit,
+        permalink=f"https://reddit.com{comment.permalink}",
+        text=comment.body,
+    )
+
+
+def match_patterns(source: TextSource, patterns: tuple[InsightPattern, ...]) -> list[Insight]:
+    lowered_text = source.text.lower()
+    insights: list[Insight] = []
+    for pattern in patterns:
+        if not pattern.regex.search(lowered_text):
+            continue
+        insights.append(
+            Insight(
+                category=pattern.category,
+                title=pattern.title,
+                summary=pattern.summary,
+                tags=pattern.tags,
+                evidence=source.text.strip(),
+                source_kind=source.source_kind,
+                source_id=source.source_id,
+                source_permalink=source.permalink,
+                source_post_id=source.source_post_id,
+                subreddit=source.subreddit,
+                why_it_matters=pattern.why_it_matters,
+            )
+        )
+    return insights

--- a/src/reddit_digest/extractors/guides.py
+++ b/src/reddit_digest/extractors/guides.py
@@ -1,0 +1,27 @@
+"""Guide and resource extraction rules."""
+
+from __future__ import annotations
+
+import re
+
+from reddit_digest.extractors.common import InsightPattern
+
+
+GUIDE_PATTERNS: tuple[InsightPattern, ...] = (
+    InsightPattern(
+        title="Local context file pattern",
+        category="guides",
+        summary="A reusable context-file pattern is being shared as a repeatable resource.",
+        why_it_matters="It gives other practitioners a concrete way to structure agent context.",
+        tags=("prompting", "coding-agents", "tooling"),
+        regex=re.compile(r"context file"),
+    ),
+    InsightPattern(
+        title="Prompt recovery checklist",
+        category="guides",
+        summary="People are sharing explicit recovery steps for resuming interrupted agent work.",
+        why_it_matters="Recovery patterns make longer-running AI workflows more reliable.",
+        tags=("reliability", "prompting", "ai-dev-workflow"),
+        regex=re.compile(r"prompt recovery|recovery"),
+    ),
+)

--- a/src/reddit_digest/extractors/service.py
+++ b/src/reddit_digest/extractors/service.py
@@ -1,0 +1,65 @@
+"""Extraction orchestration and persistence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import json
+
+from reddit_digest.extractors.approaches import APPROACH_PATTERNS
+from reddit_digest.extractors.common import comment_source
+from reddit_digest.extractors.common import match_patterns
+from reddit_digest.extractors.common import post_source
+from reddit_digest.extractors.guides import GUIDE_PATTERNS
+from reddit_digest.extractors.testing_insights import TESTING_PATTERNS
+from reddit_digest.extractors.tools import TOOL_PATTERNS
+from reddit_digest.models.comment import Comment
+from reddit_digest.models.insight import Insight
+from reddit_digest.models.post import Post
+
+
+@dataclass(frozen=True)
+class ExtractedInsights:
+    path: Path
+    insights: tuple[Insight, ...]
+
+
+def extract_insights(
+    posts: tuple[Post, ...],
+    comments: tuple[Comment, ...],
+    *,
+    processed_root: Path,
+    run_date: str,
+) -> ExtractedInsights:
+    insights = _extract(posts, comments)
+    path = processed_root / "insights" / f"{run_date}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps([item.to_dict() for item in insights], indent=2, sort_keys=True))
+    return ExtractedInsights(path=path, insights=tuple(insights))
+
+
+def _extract(posts: tuple[Post, ...], comments: tuple[Comment, ...]) -> list[Insight]:
+    extracted: list[Insight] = []
+    for post in posts:
+        source = post_source(post)
+        extracted.extend(match_patterns(source, TOOL_PATTERNS))
+        extracted.extend(match_patterns(source, APPROACH_PATTERNS))
+        extracted.extend(match_patterns(source, GUIDE_PATTERNS))
+        extracted.extend(match_patterns(source, TESTING_PATTERNS))
+
+    for comment in comments:
+        source = comment_source(comment)
+        extracted.extend(match_patterns(source, TOOL_PATTERNS))
+        extracted.extend(match_patterns(source, APPROACH_PATTERNS))
+        extracted.extend(match_patterns(source, GUIDE_PATTERNS))
+        extracted.extend(match_patterns(source, TESTING_PATTERNS))
+
+    deduped: dict[tuple[str, str, str], Insight] = {}
+    for insight in extracted:
+        key = (insight.category, insight.title, insight.source_id)
+        deduped[key] = insight
+
+    return sorted(
+        deduped.values(),
+        key=lambda insight: (insight.category, insight.title, insight.source_id),
+    )

--- a/src/reddit_digest/extractors/testing_insights.py
+++ b/src/reddit_digest/extractors/testing_insights.py
@@ -1,0 +1,27 @@
+"""Testing and quality extraction rules."""
+
+from __future__ import annotations
+
+import re
+
+from reddit_digest.extractors.common import InsightPattern
+
+
+TESTING_PATTERNS: tuple[InsightPattern, ...] = (
+    InsightPattern(
+        title="Snapshot markdown tests",
+        category="testing",
+        summary="Snapshot-style output tests are being used to catch formatting regressions.",
+        why_it_matters="Deterministic report generation becomes testable and safer to change.",
+        tags=("ai-testing", "reliability", "tooling"),
+        regex=re.compile(r"snapshot.*tests?|markdown output tests"),
+    ),
+    InsightPattern(
+        title="Deterministic prompting",
+        category="testing",
+        summary="Prompt stability is being treated as a software quality concern.",
+        why_it_matters="Repeatable prompting improves trust in AI-assisted development workflows.",
+        tags=("prompting", "reliability", "ai-testing"),
+        regex=re.compile(r"deterministic"),
+    ),
+)

--- a/src/reddit_digest/extractors/tools.py
+++ b/src/reddit_digest/extractors/tools.py
@@ -1,0 +1,27 @@
+"""Tool extraction rules."""
+
+from __future__ import annotations
+
+import re
+
+from reddit_digest.extractors.common import InsightPattern
+
+
+TOOL_PATTERNS: tuple[InsightPattern, ...] = (
+    InsightPattern(
+        title="Codex",
+        category="tools",
+        summary="Codex is being used as an agentic coding tool in real workflows.",
+        why_it_matters="It appears in hands-on discussions about practical agent-assisted coding.",
+        tags=("ai-agents", "tooling", "coding-agents"),
+        regex=re.compile(r"\bcodex\b"),
+    ),
+    InsightPattern(
+        title="Claude Code",
+        category="tools",
+        summary="Claude Code is being used to support structured software workflows.",
+        why_it_matters="It is discussed as an applied coding tool rather than generic AI chat.",
+        tags=("ai-agents", "tooling", "ai-dev-workflow"),
+        regex=re.compile(r"\bclaude code\b"),
+    ),
+)

--- a/src/reddit_digest/models/__init__.py
+++ b/src/reddit_digest/models/__init__.py
@@ -2,6 +2,7 @@
 
 from reddit_digest.models.comment import Comment
 from reddit_digest.models.digest import DigestItem
+from reddit_digest.models.insight import Insight
 from reddit_digest.models.post import Post
 
-__all__ = ["Comment", "DigestItem", "Post"]
+__all__ = ["Comment", "DigestItem", "Insight", "Post"]

--- a/src/reddit_digest/models/insight.py
+++ b/src/reddit_digest/models/insight.py
@@ -1,0 +1,50 @@
+"""Typed extracted insight model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from reddit_digest.models.base import BaseModel
+from reddit_digest.models.base import ModelError
+from reddit_digest.models.base import optional_string
+from reddit_digest.models.base import require_string
+from reddit_digest.models.base import require_string_list
+
+
+@dataclass(frozen=True)
+class Insight(BaseModel):
+    category: str
+    title: str
+    summary: str
+    tags: tuple[str, ...]
+    evidence: str
+    source_kind: str
+    source_id: str
+    source_permalink: str
+    source_post_id: str
+    subreddit: str
+    novelty: str | None = None
+    why_it_matters: str | None = None
+
+    @classmethod
+    def from_raw(cls, payload: dict[str, Any]) -> "Insight":
+        item = cls(
+            category=require_string(payload, "category"),
+            title=require_string(payload, "title"),
+            summary=require_string(payload, "summary"),
+            tags=require_string_list(payload, "tags"),
+            evidence=require_string(payload, "evidence"),
+            source_kind=require_string(payload, "source_kind"),
+            source_id=require_string(payload, "source_id"),
+            source_permalink=require_string(payload, "source_permalink"),
+            source_post_id=require_string(payload, "source_post_id"),
+            subreddit=require_string(payload, "subreddit"),
+            novelty=optional_string(payload, "novelty"),
+            why_it_matters=optional_string(payload, "why_it_matters"),
+        )
+        if item.source_kind not in {"post", "comment"}:
+            raise ModelError("'source_kind' must be 'post' or 'comment'")
+        if not item.source_permalink:
+            raise ModelError("'source_permalink' must be populated")
+        return item

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+from reddit_digest.extractors.service import extract_insights
+from reddit_digest.models.comment import Comment
+from reddit_digest.models.post import Post
+
+
+def build_posts(sample_posts_payload: list[dict[str, object]]) -> tuple[Post, ...]:
+    return tuple(Post.from_raw(item) for item in sample_posts_payload)
+
+
+def build_comments(sample_comments_payload: list[dict[str, object]]) -> tuple[Comment, ...]:
+    return tuple(Comment.from_raw(item) for item in sample_comments_payload)
+
+
+def test_extract_insights_from_posts_and_comments(
+    sample_posts_payload: list[dict[str, object]],
+    sample_comments_payload: list[dict[str, object]],
+    tmp_path: Path,
+) -> None:
+    result = extract_insights(
+        build_posts(sample_posts_payload),
+        build_comments(sample_comments_payload),
+        processed_root=tmp_path,
+        run_date="2026-03-12",
+    )
+
+    assert result.path == tmp_path / "insights" / "2026-03-12.json"
+    assert result.path.exists()
+    assert {insight.category for insight in result.insights} >= {"approaches", "testing", "tools"}
+    assert any(insight.title == "Codex" for insight in result.insights)
+    assert any(insight.source_kind == "comment" for insight in result.insights)
+
+    persisted = json.loads(result.path.read_text())
+    assert persisted[0]["category"] <= persisted[-1]["category"]
+
+
+def test_extract_insights_handles_no_matches(sample_posts_payload: list[dict[str, object]], tmp_path: Path) -> None:
+    bland_post = dict(sample_posts_payload[0])
+    bland_post["title"] = "Weekend check-in"
+    bland_post["selftext"] = "Just saying hi."
+
+    result = extract_insights(
+        (Post.from_raw(bland_post),),
+        (),
+        processed_root=tmp_path,
+        run_date="2026-03-12",
+    )
+
+    assert result.insights == ()
+    assert json.loads(result.path.read_text()) == []


### PR DESCRIPTION
## Summary
- add a typed insight model and deterministic rule-based extraction helpers
- extract tools, approaches, guides, and testing insights from posts and comments
- persist normalized extraction output for downstream scoring and reporting

Closes #6

## Testing
- uv run pytest tests/test_extractors.py tests/test_models.py tests/test_reddit_posts.py tests/test_reddit_comments.py tests/test_config.py
- uv run python -m compileall src tests