### PR TITLE
Implement impact scoring

### DIFF
--- a/src/reddit_digest/ranking/__init__.py
+++ b/src/reddit_digest/ranking/__init__.py
@@ -1,1 +1,7 @@
 """Ranking modules."""
+
+from reddit_digest.ranking.impact import ScoreBreakdown
+from reddit_digest.ranking.impact import score_insight
+from reddit_digest.ranking.impact import score_post
+
+__all__ = ["ScoreBreakdown", "score_insight", "score_post"]

--- a/src/reddit_digest/ranking/impact.py
+++ b/src/reddit_digest/ranking/impact.py
@@ -1,0 +1,79 @@
+"""Deterministic post and insight scoring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC
+from datetime import datetime
+
+from reddit_digest.config import ScoringConfig
+from reddit_digest.models.insight import Insight
+from reddit_digest.models.post import Post
+
+
+RELEVANCE_TERMS = ("agent", "codex", "claude", "workflow", "test", "eval", "prompt", "automation")
+ACTIONABLE_TERMS = ("guide", "how", "workflow", "template", "snapshot", "checklist", "refactor", "context")
+
+
+@dataclass(frozen=True)
+class ScoreBreakdown:
+    components: dict[str, float]
+    total: float
+
+
+def score_post(post: Post, scoring: ScoringConfig, *, run_at: datetime, lookback_hours: int) -> ScoreBreakdown:
+    text = " ".join(part for part in [post.title, post.selftext or ""] if part).lower()
+    components = {
+        "relevance": _term_density(text, RELEVANCE_TERMS),
+        "comment_depth": min(post.num_comments / 20, 1.0),
+        "actionability": _term_density(text, ACTIONABLE_TERMS),
+        "novelty": 0.5,
+        "engagement": min(max(post.score, 0) / 100, 1.0),
+        "recency": _recency_score(post.created_utc, run_at=run_at, lookback_hours=lookback_hours),
+    }
+    return ScoreBreakdown(components=components, total=_weighted_total(components, scoring))
+
+
+def score_insight(insight: Insight, scoring: ScoringConfig) -> ScoreBreakdown:
+    tags = set(insight.tags)
+    configured_tags = set(scoring.tags)
+    overlap = len(tags & configured_tags)
+    actionability_signal = " ".join(
+        part for part in [insight.summary, insight.why_it_matters or "", insight.evidence] if part
+    ).lower()
+    components = {
+        "relevance": min(overlap / max(len(tags), 1), 1.0),
+        "comment_depth": 1.0 if insight.source_kind == "comment" else 0.6,
+        "actionability": _term_density(actionability_signal, ACTIONABLE_TERMS),
+        "novelty": _novelty_component(insight.novelty),
+        "engagement": min(len(insight.evidence.split()) / 25, 1.0),
+        "recency": 1.0,
+    }
+    return ScoreBreakdown(components=components, total=_weighted_total(components, scoring))
+
+
+def _term_density(text: str, terms: tuple[str, ...]) -> float:
+    matches = sum(1 for term in terms if term in text)
+    return min(matches / 3, 1.0)
+
+
+def _recency_score(created_utc: int, *, run_at: datetime, lookback_hours: int) -> float:
+    age_hours = max((run_at - datetime.fromtimestamp(created_utc, tz=UTC)).total_seconds() / 3600, 0)
+    if lookback_hours <= 0:
+        return 0.0
+    return max(0.0, 1 - (age_hours / lookback_hours))
+
+
+def _novelty_component(novelty: str | None) -> float:
+    if novelty == "new":
+        return 1.0
+    if novelty == "ongoing":
+        return 0.25
+    return 0.5
+
+
+def _weighted_total(components: dict[str, float], scoring: ScoringConfig) -> float:
+    total = 0.0
+    for name, weight in scoring.weights.items():
+        total += components.get(name, 0.0) * weight
+    return round(total * 10, 2)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from datetime import UTC
+from datetime import datetime
+from pathlib import Path
+
+from reddit_digest.config import load_scoring_config
+from reddit_digest.extractors.service import extract_insights
+from reddit_digest.models.comment import Comment
+from reddit_digest.models.insight import Insight
+from reddit_digest.models.post import Post
+from reddit_digest.ranking.impact import score_insight
+from reddit_digest.ranking.impact import score_post
+
+
+CONFIG_PATH = Path.cwd() / "config" / "scoring.yaml"
+
+
+def test_score_post_returns_deterministic_breakdown(sample_posts_payload: list[dict[str, object]]) -> None:
+    post = Post.from_raw(sample_posts_payload[0])
+    scoring = load_scoring_config(CONFIG_PATH)
+
+    first = score_post(
+        post,
+        scoring,
+        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+        lookback_hours=24,
+    )
+    second = score_post(
+        post,
+        scoring,
+        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+        lookback_hours=24,
+    )
+
+    assert first == second
+    assert set(first.components) == {"relevance", "comment_depth", "actionability", "novelty", "engagement", "recency"}
+    assert first.total > 0
+
+
+def test_score_insight_uses_config_weights(
+    sample_posts_payload: list[dict[str, object]],
+    sample_comments_payload: list[dict[str, object]],
+    tmp_path,
+) -> None:
+    scoring = load_scoring_config(CONFIG_PATH)
+    extraction = extract_insights(
+        tuple(Post.from_raw(item) for item in sample_posts_payload),
+        tuple(Comment.from_raw(item) for item in sample_comments_payload),
+        processed_root=tmp_path,
+        run_date="2026-03-12",
+    )
+    insight = next(item for item in extraction.insights if item.title == "Codex")
+
+    breakdown = score_insight(insight, scoring)
+
+    assert breakdown.components["relevance"] > 0
+    assert breakdown.total > 0
+    assert round(sum(scoring.weights.values()), 2) == 1.0
+
+
+def test_ongoing_novelty_scores_lower_than_new(sample_posts_payload: list[dict[str, object]]) -> None:
+    scoring = load_scoring_config(CONFIG_PATH)
+    base_payload = {
+        "category": "testing",
+        "title": "Snapshot markdown tests",
+        "summary": "Snapshot-style output tests are being used to catch regressions.",
+        "tags": ["ai-testing", "reliability"],
+        "evidence": "Snapshot markdown tests catch regressions.",
+        "source_kind": "comment",
+        "source_id": "comment_001",
+        "source_post_id": "post_001",
+        "source_permalink": "https://reddit.com/r/Codex/comments/post_001/comment_001/",
+        "subreddit": "Codex",
+        "why_it_matters": "Deterministic output becomes enforceable.",
+    }
+    new_item = Insight.from_raw({**base_payload, "novelty": "new"})
+    ongoing_item = Insight.from_raw({**base_payload, "novelty": "ongoing"})
+
+    assert score_insight(new_item, scoring).total > score_insight(ongoing_item, scoring).total


### PR DESCRIPTION
## Summary
- add deterministic post and insight scoring with explicit component breakdowns
- apply configured weights from scoring.yaml to compute stable totals
- cover deterministic behavior and novelty weighting with tests

Closes #7

## Testing
- uv run pytest tests/test_scoring.py tests/test_extractors.py tests/test_models.py tests/test_reddit_posts.py tests/test_reddit_comments.py tests/test_config.py
- uv run python -m compileall src tests