### PR TITLE
Add novelty vs yesterday

### DIFF
--- a/src/reddit_digest/ranking/__init__.py
+++ b/src/reddit_digest/ranking/__init__.py
@@ -3,5 +3,6 @@
 from reddit_digest.ranking.impact import ScoreBreakdown
 from reddit_digest.ranking.impact import score_insight
 from reddit_digest.ranking.impact import score_post
+from reddit_digest.ranking.novelty import apply_novelty
 
-__all__ = ["ScoreBreakdown", "score_insight", "score_post"]
+__all__ = ["ScoreBreakdown", "apply_novelty", "score_insight", "score_post"]

--- a/src/reddit_digest/ranking/novelty.py
+++ b/src/reddit_digest/ranking/novelty.py
@@ -1,0 +1,60 @@
+"""Novelty comparison against the most recent prior run."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import re
+
+from reddit_digest.models.insight import Insight
+
+
+@dataclass(frozen=True)
+class NoveltyResult:
+    path: Path
+    insights: tuple[Insight, ...]
+
+
+def apply_novelty(processed_root: Path, *, run_date: str, insights: tuple[Insight, ...]) -> NoveltyResult:
+    previous_insights = _load_previous_insights(processed_root, run_date=run_date)
+    previous_keys = {_match_key(insight) for insight in previous_insights}
+
+    updated = tuple(
+        replace(
+            insight,
+            novelty="ongoing" if _match_key(insight) in previous_keys else "new",
+        )
+        for insight in insights
+    )
+
+    path = processed_root / "insights" / f"{run_date}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps([insight.to_dict() for insight in updated], indent=2, sort_keys=True))
+    return NoveltyResult(path=path, insights=updated)
+
+
+def _load_previous_insights(processed_root: Path, *, run_date: str) -> tuple[Insight, ...]:
+    insight_dir = processed_root / "insights"
+    if not insight_dir.exists():
+        return ()
+
+    prior_paths = sorted(path for path in insight_dir.glob("*.json") if path.stem < run_date)
+    if not prior_paths:
+        return ()
+
+    payload = json.loads(prior_paths[-1].read_text())
+    return tuple(Insight.from_raw(item) for item in payload)
+
+
+def _match_key(insight: Insight) -> tuple[str, str, str]:
+    return (
+        insight.category,
+        _normalize_text(insight.title),
+        _normalize_text(insight.summary),
+    )
+
+
+def _normalize_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip().lower())

--- a/tests/test_novelty.py
+++ b/tests/test_novelty.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+from reddit_digest.models.insight import Insight
+from reddit_digest.ranking.novelty import apply_novelty
+
+
+def build_insight(**overrides: str) -> Insight:
+    base = {
+        "category": "tools",
+        "title": "Codex",
+        "summary": "Codex is being used as an agentic coding tool in real workflows.",
+        "tags": ["ai-agents", "tooling"],
+        "evidence": "Codex shows up in the thread and the comments.",
+        "source_kind": "post",
+        "source_id": "post_001",
+        "source_post_id": "post_001",
+        "source_permalink": "https://reddit.com/r/Codex/comments/post_001",
+        "subreddit": "Codex",
+        "why_it_matters": "It appears in practical coding discussions.",
+    }
+    return Insight.from_raw({**base, **overrides})
+
+
+def test_apply_novelty_marks_all_items_new_without_prior_run(tmp_path: Path) -> None:
+    result = apply_novelty(tmp_path, run_date="2026-03-12", insights=(build_insight(),))
+
+    assert [insight.novelty for insight in result.insights] == ["new"]
+    assert json.loads(result.path.read_text())[0]["novelty"] == "new"
+
+
+def test_apply_novelty_marks_matching_items_ongoing(tmp_path: Path) -> None:
+    prior_path = tmp_path / "insights" / "2026-03-11.json"
+    prior_path.parent.mkdir(parents=True, exist_ok=True)
+    prior_path.write_text(json.dumps([build_insight().to_dict()], indent=2, sort_keys=True))
+
+    current_items = (
+        build_insight(source_id="post_002", source_post_id="post_002"),
+        build_insight(
+            category="testing",
+            title="Snapshot markdown tests",
+            summary="Snapshot-style output tests are being used to catch formatting regressions.",
+            tags=["ai-testing", "reliability"],
+            evidence="Snapshot markdown tests catch regressions.",
+            source_kind="comment",
+            source_id="comment_001",
+            source_post_id="post_001",
+            source_permalink="https://reddit.com/r/Codex/comments/post_001/comment_001/",
+            why_it_matters="Deterministic output remains enforceable.",
+        ),
+    )
+
+    result = apply_novelty(tmp_path, run_date="2026-03-12", insights=current_items)
+
+    novelty_by_title = {insight.title: insight.novelty for insight in result.insights}
+    assert novelty_by_title["Codex"] == "ongoing"
+    assert novelty_by_title["Snapshot markdown tests"] == "new"


### PR DESCRIPTION
## Summary
- compare extracted insights against the most recent prior run
- mark insights as new or ongoing using deterministic matching keys
- persist novelty-annotated insight output for downstream scoring and rendering

Closes #15

## Testing
- uv run pytest tests/test_novelty.py tests/test_scoring.py tests/test_extractors.py tests/test_models.py tests/test_reddit_posts.py tests/test_reddit_comments.py tests/test_config.py
- uv run python -m compileall src tests