### PR TITLE
Generate daily Markdown digest

### DIFF
--- a/src/reddit_digest/outputs/markdown.py
+++ b/src/reddit_digest/outputs/markdown.py
@@ -1,0 +1,159 @@
+"""Markdown digest rendering."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from datetime import UTC
+from datetime import datetime
+from pathlib import Path
+
+from reddit_digest.config import ScoringConfig
+from reddit_digest.models.insight import Insight
+from reddit_digest.models.post import Post
+from reddit_digest.ranking.impact import score_insight
+from reddit_digest.ranking.impact import score_post
+
+
+@dataclass(frozen=True)
+class MarkdownDigestResult:
+    daily_path: Path
+    latest_path: Path
+    content: str
+
+
+def render_markdown_digest(
+    *,
+    run_date: str,
+    posts: tuple[Post, ...],
+    insights: tuple[Insight, ...],
+    scoring: ScoringConfig,
+    reports_root: Path,
+    lookback_hours: int,
+    watch_next: tuple[str, ...] = (),
+    run_at: datetime | None = None,
+) -> MarkdownDigestResult:
+    effective_run_at = run_at or datetime.now(tz=UTC)
+    scored_posts = sorted(
+        [(post, score_post(post, scoring, run_at=effective_run_at, lookback_hours=lookback_hours)) for post in posts],
+        key=lambda item: (-item[1].total, item[0].id),
+    )
+    scored_insights = sorted(
+        [(insight, score_insight(insight, scoring)) for insight in insights],
+        key=lambda item: (item[0].category, -item[1].total, item[0].title, item[0].source_id),
+    )
+
+    lines = [f"# Daily Reddit Digest — {run_date}", ""]
+    lines.extend(_render_executive_summary(scored_posts, scored_insights))
+    lines.extend(_render_insight_section("Top Tools Mentioned", "tools", scored_insights))
+    lines.extend(_render_insight_section("Top Approaches / Workflows", "approaches", scored_insights))
+    lines.extend(_render_insight_section("Top Guides / Resources", "guides", scored_insights))
+    lines.extend(_render_insight_section("Testing and Quality Insights", "testing", scored_insights))
+    lines.extend(_render_notable_threads(scored_posts, scored_insights))
+    lines.extend(_render_emerging_themes(scored_insights))
+    watch_next_lines = _render_watch_next(watch_next=watch_next, scored_insights=scored_insights)
+    if watch_next_lines:
+        lines.extend(watch_next_lines)
+
+    content = "\n".join(lines).strip() + "\n"
+    daily_path = reports_root / "daily" / f"{run_date}.md"
+    latest_path = reports_root / "latest.md"
+    daily_path.parent.mkdir(parents=True, exist_ok=True)
+    daily_path.write_text(content)
+    latest_path.write_text(content)
+    return MarkdownDigestResult(daily_path=daily_path, latest_path=latest_path, content=content)
+
+
+def _render_executive_summary(scored_posts: list[tuple[Post, object]], scored_insights: list[tuple[Insight, object]]) -> list[str]:
+    top_post = scored_posts[0][0] if scored_posts else None
+    top_insights = [insight.title for insight, _ in scored_insights[:2]]
+    bullets = [
+        "## Executive Summary",
+        *(f"- Top thread: {top_post.title}" for _ in [0] if top_post is not None),
+        *(f"- Leading insights: {', '.join(top_insights)}" for _ in [0] if top_insights),
+        f"- Total posts analyzed: {len(scored_posts)}",
+        f"- Total insights extracted: {len(scored_insights)}",
+        "",
+    ]
+    return bullets
+
+
+def _render_insight_section(
+    heading: str,
+    category: str,
+    scored_insights: list[tuple[Insight, object]],
+) -> list[str]:
+    lines = [f"## {heading}"]
+    matching = [(insight, breakdown) for insight, breakdown in scored_insights if insight.category == category][:3]
+    if not matching:
+        lines.append("- No significant items today.")
+        lines.append("")
+        return lines
+
+    for insight, breakdown in matching:
+        lines.append(f"- {insight.title}")
+        lines.append(f"  - Why it matters: {insight.why_it_matters or insight.summary}")
+        lines.append(f"  - Source threads: 1")
+        lines.append(f"  - Impact score: {breakdown.total:.2f}")
+    lines.append("")
+    return lines
+
+
+def _render_notable_threads(
+    scored_posts: list[tuple[Post, object]],
+    scored_insights: list[tuple[Insight, object]],
+) -> list[str]:
+    lines = ["## Notable Threads"]
+    top_posts = scored_posts[:5]
+    if not top_posts:
+        lines.append("- No notable threads today.")
+        lines.append("")
+        return lines
+
+    for post, breakdown in top_posts:
+        related = [insight for insight, _ in scored_insights if insight.source_post_id == post.id]
+        why_it_matters = related[0].why_it_matters if related and related[0].why_it_matters else "Relevant discussion for AI-assisted development workflows."
+        tags = sorted({tag for insight in related for tag in insight.tags})
+        summary = (post.selftext or post.title).strip()
+        lines.append(f"- [{post.title}]({post.url})")
+        lines.append(f"  - Subreddit: r/{post.subreddit}")
+        lines.append(f"  - Summary: {summary}")
+        lines.append(f"  - Why it matters: {why_it_matters}")
+        lines.append(f"  - Impact score: {breakdown.total:.2f}")
+        lines.append(f"  - Extracted tags: {', '.join(tags) if tags else 'none'}")
+    lines.append("")
+    return lines
+
+
+def _render_emerging_themes(scored_insights: list[tuple[Insight, object]]) -> list[str]:
+    lines = ["## Emerging Themes"]
+    tags = Counter(tag for insight, _ in scored_insights for tag in insight.tags)
+    if not tags:
+        lines.append("- No emerging themes today.")
+        lines.append("")
+        return lines
+
+    for tag, _count in tags.most_common(3):
+        evidence = ", ".join(insight.title for insight, _ in scored_insights if tag in insight.tags)
+        lines.append(f"- {tag.replace('-', ' ').title()}")
+        lines.append(f"  - Evidence: {evidence}")
+    lines.append("")
+    return lines
+
+
+def _render_watch_next(
+    *,
+    watch_next: tuple[str, ...],
+    scored_insights: list[tuple[Insight, object]],
+) -> list[str]:
+    suggestions = list(watch_next)
+    if not suggestions:
+        suggestions = [insight.title for insight, _ in scored_insights if insight.novelty == "new"][:3]
+    if not suggestions:
+        return []
+
+    lines = ["## Watch Next"]
+    for item in suggestions:
+        lines.append(f"- {item}")
+    lines.append("")
+    return lines

--- a/tests/test_markdown_output.py
+++ b/tests/test_markdown_output.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import UTC
+from datetime import datetime
+from pathlib import Path
+
+from reddit_digest.config import load_scoring_config
+from reddit_digest.extractors.service import extract_insights
+from reddit_digest.models.comment import Comment
+from reddit_digest.models.post import Post
+from reddit_digest.outputs.markdown import render_markdown_digest
+from reddit_digest.ranking.novelty import apply_novelty
+
+
+def test_render_markdown_digest_writes_daily_and_latest(
+    sample_posts_payload: list[dict[str, object]],
+    sample_comments_payload: list[dict[str, object]],
+    tmp_path: Path,
+) -> None:
+    posts = tuple(Post.from_raw(item) for item in sample_posts_payload)
+    comments = tuple(Comment.from_raw(item) for item in sample_comments_payload)
+    extracted = extract_insights(posts, comments, processed_root=tmp_path / "processed", run_date="2026-03-12")
+    novelty = apply_novelty(tmp_path / "processed", run_date="2026-03-12", insights=extracted.insights)
+    scoring = load_scoring_config(Path.cwd() / "config" / "scoring.yaml")
+
+    result = render_markdown_digest(
+        run_date="2026-03-12",
+        posts=posts,
+        insights=novelty.insights,
+        scoring=scoring,
+        reports_root=tmp_path / "reports",
+        lookback_hours=24,
+        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+    )
+
+    assert result.daily_path.exists()
+    assert result.latest_path.exists()
+    assert result.daily_path.read_text() == result.latest_path.read_text()
+    assert "## Executive Summary" in result.content
+    assert "## Top Tools Mentioned" in result.content
+    assert "## Notable Threads" in result.content
+    assert "## Emerging Themes" in result.content
+
+
+def test_markdown_digest_section_order(
+    sample_posts_payload: list[dict[str, object]],
+    sample_comments_payload: list[dict[str, object]],
+    tmp_path: Path,
+) -> None:
+    posts = tuple(Post.from_raw(item) for item in sample_posts_payload)
+    comments = tuple(Comment.from_raw(item) for item in sample_comments_payload)
+    extracted = extract_insights(posts, comments, processed_root=tmp_path / "processed", run_date="2026-03-12")
+    novelty = apply_novelty(tmp_path / "processed", run_date="2026-03-12", insights=extracted.insights)
+    scoring = load_scoring_config(Path.cwd() / "config" / "scoring.yaml")
+
+    result = render_markdown_digest(
+        run_date="2026-03-12",
+        posts=posts,
+        insights=novelty.insights,
+        scoring=scoring,
+        reports_root=tmp_path / "reports",
+        lookback_hours=24,
+        watch_next=("Monitor prompt-state snapshots",),
+        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+    )
+
+    sections = [
+        "## Executive Summary",
+        "## Top Tools Mentioned",
+        "## Top Approaches / Workflows",
+        "## Top Guides / Resources",
+        "## Testing and Quality Insights",
+        "## Notable Threads",
+        "## Emerging Themes",
+        "## Watch Next",
+    ]
+    positions = [result.content.index(section) for section in sections]
+    assert positions == sorted(positions)


### PR DESCRIPTION
## Summary
- add deterministic markdown rendering for the daily digest and latest report
- derive section content from scored posts and insights
- cover file output and section-order expectations with tests

Closes #8

## Testing
- uv run pytest tests/test_markdown_output.py tests/test_novelty.py tests/test_scoring.py tests/test_extractors.py tests/test_models.py tests/test_reddit_posts.py tests/test_reddit_comments.py tests/test_config.py
- uv run python -m compileall src tests