### PR TITLE
Add retry, logging, and state handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Run the package entrypoint:
 uv run reddit-digest --help
 ```
 
+Run the full daily pipeline locally without Sheets export:
+
+```bash
+uv run reddit-digest run-daily --date 2026-03-12 --skip-sheets
+```
+
 Run tests:
 
 ```bash

--- a/src/reddit_digest/cli.py
+++ b/src/reddit_digest/cli.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import argparse
+from datetime import date
+from pathlib import Path
 from typing import Sequence
 
+from reddit_digest.pipeline import PipelineRunner
+from reddit_digest.utils.logging import configure_logging
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="reddit-digest")
@@ -13,18 +17,25 @@ def build_parser() -> argparse.ArgumentParser:
         action="version",
         version="reddit-ai-agents-digest 0.1.0",
     )
-    parser.add_argument(
-        "command",
-        nargs="?",
-        default="help",
-        help="Reserved for future pipeline commands.",
-    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    run_daily = subparsers.add_parser("run-daily", help="Run the full daily digest pipeline.")
+    run_daily.add_argument("--date", dest="run_date", default=date.today().isoformat(), help="Run date in YYYY-MM-DD format.")
+    run_daily.add_argument("--base-path", default=".", help="Repository base path.")
+    run_daily.add_argument("--skip-sheets", action="store_true", help="Skip Google Sheets export.")
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
-    parser.parse_args(argv)
+    args = parser.parse_args(argv)
+
+    if args.command == "run-daily":
+        configure_logging()
+        runner = PipelineRunner(base_path=Path(args.base_path))
+        runner.run(run_date=args.run_date, skip_sheets=args.skip_sheets)
+        return 0
+
     parser.print_help()
     return 0
 

--- a/src/reddit_digest/pipeline.py
+++ b/src/reddit_digest/pipeline.py
@@ -1,0 +1,118 @@
+"""Pipeline orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC
+from datetime import datetime
+from pathlib import Path
+import json
+import logging
+
+import praw
+
+from reddit_digest.collectors.reddit_comments import CommentCollector
+from reddit_digest.collectors.reddit_comments import PrawRedditCommentSource
+from reddit_digest.collectors.reddit_posts import PrawRedditPostSource
+from reddit_digest.collectors.reddit_posts import PostCollector
+from reddit_digest.config import load_config
+from reddit_digest.outputs.google_sheets import GoogleSheetsExporter
+from reddit_digest.outputs.markdown import render_markdown_digest
+from reddit_digest.extractors.service import extract_insights
+from reddit_digest.ranking.novelty import apply_novelty
+from reddit_digest.utils.retries import retry_call
+from reddit_digest.utils.state import RunState
+from reddit_digest.utils.state import write_run_state
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class PipelineRunner:
+    base_path: Path
+
+    def run(self, *, run_date: str, skip_sheets: bool = False) -> RunState:
+        config = load_config(
+            self.base_path,
+            require_reddit=True,
+            require_sheets=not skip_sheets,
+        )
+        run_at = datetime.fromisoformat(f"{run_date}T12:00:00+00:00").astimezone(UTC)
+
+        post_source = PrawRedditPostSource(config.runtime)
+        reddit = praw.Reddit(
+            client_id=config.runtime.reddit_client_id,
+            client_secret=config.runtime.reddit_client_secret,
+            user_agent=config.runtime.reddit_user_agent,
+        )
+        reddit.read_only = True
+        comment_source = PrawRedditCommentSource(lambda post_id: reddit.submission(id=post_id))
+
+        post_result = retry_call(
+            lambda: PostCollector(post_source, self.base_path / "data" / "raw", self.base_path / "data" / "processed").collect(
+                config.subreddits,
+                run_at=run_at,
+            ),
+            operation="collect_posts",
+            logger=LOGGER,
+        )
+        comment_result = retry_call(
+            lambda: CommentCollector(
+                comment_source,
+                self.base_path / "data" / "raw",
+                self.base_path / "data" / "processed",
+            ).collect(
+                post_result.posts,
+                max_comments_per_post=config.subreddits.fetch.max_comments_per_post,
+                run_at=run_at,
+            ),
+            operation="collect_comments",
+            logger=LOGGER,
+        )
+        extracted = extract_insights(
+            post_result.posts,
+            comment_result.comments,
+            processed_root=self.base_path / "data" / "processed",
+            run_date=run_date,
+        )
+        novelty = apply_novelty(self.base_path / "data" / "processed", run_date=run_date, insights=extracted.insights)
+        markdown = render_markdown_digest(
+            run_date=run_date,
+            posts=post_result.posts,
+            insights=novelty.insights,
+            scoring=config.scoring,
+            reports_root=self.base_path / "reports",
+            lookback_hours=config.subreddits.fetch.lookback_hours,
+            run_at=run_at,
+        )
+
+        sheets_exported = False
+        if not skip_sheets:
+            retry_call(
+                lambda: GoogleSheetsExporter.from_runtime(config.runtime).export(
+                    run_date=run_date,
+                    posts=post_result.posts,
+                    insights=novelty.insights,
+                    markdown_content=markdown.content,
+                    scoring=config.scoring,
+                    lookback_hours=config.subreddits.fetch.lookback_hours,
+                    run_at=run_at,
+                ),
+                operation="export_google_sheets",
+                logger=LOGGER,
+            )
+            sheets_exported = True
+
+        state = RunState(
+            run_date=run_date,
+            completed_at=datetime.now(tz=UTC).isoformat(),
+            raw_posts_path=str(post_result.raw_path.relative_to(self.base_path)),
+            raw_comments_path=str(comment_result.raw_path.relative_to(self.base_path)),
+            insights_path=str(novelty.path.relative_to(self.base_path)),
+            report_path=str(markdown.daily_path.relative_to(self.base_path)),
+            sheets_exported=sheets_exported,
+        )
+        write_run_state(self.base_path / "data" / "state", state)
+        LOGGER.info("Pipeline completed for %s", run_date)
+        return state

--- a/src/reddit_digest/utils/logging.py
+++ b/src/reddit_digest/utils/logging.py
@@ -1,0 +1,12 @@
+"""Logging helpers."""
+
+from __future__ import annotations
+
+import logging
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )

--- a/src/reddit_digest/utils/retries.py
+++ b/src/reddit_digest/utils/retries.py
@@ -1,0 +1,33 @@
+"""Retry helpers for transient operations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import logging
+import time
+from typing import TypeVar
+
+
+T = TypeVar("T")
+
+
+def retry_call(
+    func: Callable[[], T],
+    *,
+    operation: str,
+    logger: logging.Logger,
+    attempts: int = 3,
+    delay_seconds: float = 0.25,
+) -> T:
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return func()
+        except Exception as exc:
+            last_error = exc
+            logger.warning("%s failed on attempt %s/%s: %s", operation, attempt, attempts, exc)
+            if attempt == attempts:
+                break
+            time.sleep(delay_seconds)
+    assert last_error is not None
+    raise last_error

--- a/src/reddit_digest/utils/state.py
+++ b/src/reddit_digest/utils/state.py
@@ -1,0 +1,28 @@
+"""Run state persistence."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from dataclasses import dataclass
+from pathlib import Path
+import json
+
+
+@dataclass(frozen=True)
+class RunState:
+    run_date: str
+    completed_at: str
+    raw_posts_path: str
+    raw_comments_path: str
+    insights_path: str
+    report_path: str
+    sheets_exported: bool
+
+
+def write_run_state(state_root: Path, state: RunState) -> None:
+    state_root.mkdir(parents=True, exist_ok=True)
+    dated_path = state_root / f"{state.run_date}.json"
+    latest_path = state_root / "latest.json"
+    payload = json.dumps(asdict(state), indent=2, sort_keys=True)
+    dated_path.write_text(payload)
+    latest_path.write_text(payload)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -5,6 +5,7 @@ from reddit_digest.cli import build_parser, main
 def test_package_imports() -> None:
     assert __version__ == "0.1.0"
     assert build_parser().prog == "reddit-digest"
+    assert "run-daily" in build_parser()._subparsers._group_actions[0].choices
 
 
 def test_cli_main_returns_success() -> None:

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import logging
+import pytest
+
+from reddit_digest.utils.retries import retry_call
+from reddit_digest.utils.state import RunState
+from reddit_digest.utils.state import write_run_state
+
+
+def test_retry_call_retries_until_success(caplog: pytest.LogCaptureFixture) -> None:
+    logger = logging.getLogger("retry-test")
+    attempts = {"count": 0}
+
+    def flaky() -> str:
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise RuntimeError("temporary")
+        return "ok"
+
+    with caplog.at_level(logging.WARNING):
+        result = retry_call(flaky, operation="flaky_op", logger=logger, attempts=3, delay_seconds=0)
+
+    assert result == "ok"
+    assert attempts["count"] == 3
+    assert "flaky_op failed on attempt 1/3" in caplog.text
+
+
+def test_write_run_state_updates_dated_and_latest_files(tmp_path: Path) -> None:
+    state = RunState(
+        run_date="2026-03-12",
+        completed_at="2026-03-12T12:00:00+00:00",
+        raw_posts_path="data/raw/posts/2026-03-12.json",
+        raw_comments_path="data/raw/comments/2026-03-12.json",
+        insights_path="data/processed/insights/2026-03-12.json",
+        report_path="reports/daily/2026-03-12.md",
+        sheets_exported=True,
+    )
+
+    write_run_state(tmp_path, state)
+
+    assert (tmp_path / "2026-03-12.json").exists()
+    assert (tmp_path / "latest.json").read_text() == (tmp_path / "2026-03-12.json").read_text()


### PR DESCRIPTION
## Summary
- add the run-daily pipeline runner and CLI subcommand
- add retry helpers, logging setup, and persisted run-state files
- document the local pipeline command and cover the reliability helpers with tests

Closes #11

## Testing
- uv run pytest tests/test_reliability.py tests/test_imports.py tests/test_google_sheets.py tests/test_markdown_output.py tests/test_novelty.py tests/test_scoring.py tests/test_extractors.py tests/test_models.py tests/test_reddit_posts.py tests/test_reddit_comments.py tests/test_config.py
- uv run reddit-digest --help
- uv run python -m compileall src tests