### PR TITLE
Add daily GitHub Actions workflow

### DIFF
--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -1,0 +1,47 @@
+name: Daily Reddit Digest
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 7 * * *"
+
+jobs:
+  run-digest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      REDDIT_CLIENT_ID: ${{ secrets.REDDIT_CLIENT_ID }}
+      REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
+      REDDIT_USER_AGENT: ${{ secrets.REDDIT_USER_AGENT }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
+      GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
+      GOOGLE_SHEETS_SPREADSHEET_ID: ${{ secrets.GOOGLE_SHEETS_SPREADSHEET_ID }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run daily digest pipeline
+        run: uv run reddit-digest run-daily
+
+      - name: Upload pipeline artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily-digest-failure-artifacts
+          path: |
+            reports/
+            data/processed/
+            data/state/
+          if-no-files-found: warn

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -55,3 +55,25 @@ uv run reddit-digest run-daily --date 2026-03-12
 - Same-day reruns overwrite file outputs deterministically.
 - Sheets export replaces existing rows for the same `run_date`.
 - The latest completed state is mirrored into `data/state/latest.json`.
+
+## GitHub Actions
+
+The scheduled workflow lives at `.github/workflows/daily-digest.yml`.
+
+It supports:
+- daily scheduled runs at `07:00 UTC`
+- manual dispatch from the GitHub Actions UI
+
+Repository secrets required for the full automated run:
+- `REDDIT_CLIENT_ID`
+- `REDDIT_CLIENT_SECRET`
+- `REDDIT_USER_AGENT`
+- `GOOGLE_SERVICE_ACCOUNT_JSON`
+- `GOOGLE_SHEETS_SPREADSHEET_ID`
+
+Optional secrets:
+- `OPENAI_API_KEY`
+- `OPENAI_MODEL`
+
+On workflow failure, the action uploads `reports/`, `data/processed/`, and
+`data/state/` as an artifact for debugging.


### PR DESCRIPTION
## Summary
- add a scheduled and manually runnable GitHub Actions workflow for the pipeline
- install Python and uv in CI, then execute the run-daily command
- document the required repository secrets and upload useful artifacts on failure

Closes #10

## Testing
- uv run pytest
- uv run python - <<'PY'
from pathlib import Path
import yaml
print(yaml.safe_load(Path('.github/workflows/daily-digest.yml').read_text())['name'])
PY