### PR TITLE
Use OIDC for Google auth in Actions

### DIFF
--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -9,15 +9,25 @@ jobs:
   run-digest:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
     env:
       REDDIT_USER_AGENT: ${{ secrets.REDDIT_USER_AGENT }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
-      GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
-      GOOGLE_SHEETS_SPREADSHEET_ID: ${{ secrets.GOOGLE_SHEETS_SPREADSHEET_ID }}
+      GOOGLE_SHEETS_SPREADSHEET_ID: ${{ vars.GOOGLE_SHEETS_SPREADSHEET_ID }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}
+          create_credentials_file: true
+          export_environment_variables: true
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 __pycache__/
 .pytest_cache/
 .mypy_cache/
+gha-creds-*.json
 data/raw/*
 data/processed/*
 data/state/*

--- a/README.md
+++ b/README.md
@@ -64,8 +64,13 @@ use Reddit's public JSON endpoints with a configurable `REDDIT_USER_AGENT`.
 
 Google Sheets export now supports ambient Google credentials from Application
 Default Credentials, including Workload Identity Federation in CI. The existing
-`GOOGLE_SERVICE_ACCOUNT_JSON` input remains a backward-compatible fallback until
-the workflow migration is completed.
+`GOOGLE_SERVICE_ACCOUNT_JSON` input remains a backward-compatible local
+fallback.
+
+The GitHub Actions workflow now authenticates to Google Cloud with OIDC via
+`google-github-actions/auth`. Set `GCP_WORKLOAD_IDENTITY_PROVIDER`,
+`GCP_SERVICE_ACCOUNT_EMAIL`, and `GOOGLE_SHEETS_SPREADSHEET_ID` as repository
+variables for CI; do not store a Google service account JSON key in GitHub.
 
 ## Repository layout
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -8,10 +8,11 @@ uv sync --dev
 
 Required environment variables for the full pipeline:
 - `REDDIT_USER_AGENT`
-- `GCP_WORKLOAD_IDENTITY_PROVIDER`
-- `GCP_SERVICE_ACCOUNT_EMAIL`
-- `GOOGLE_SERVICE_ACCOUNT_JSON`
 - `GOOGLE_SHEETS_SPREADSHEET_ID`
+
+Google authentication for Sheets can come from either:
+- ambient Application Default Credentials, including Workload Identity Federation in CI
+- `GOOGLE_SERVICE_ACCOUNT_JSON` as a backward-compatible local fallback
 
 Optional environment variables:
 - `OPENAI_API_KEY`
@@ -64,16 +65,21 @@ It supports:
 - daily scheduled runs at `07:00 UTC`
 - manual dispatch from the GitHub Actions UI
 
-Repository secrets required for the full automated run:
-- `REDDIT_USER_AGENT`
+Repository variables required for the GitHub Actions Sheets path:
 - `GCP_WORKLOAD_IDENTITY_PROVIDER`
 - `GCP_SERVICE_ACCOUNT_EMAIL`
-- `GOOGLE_SERVICE_ACCOUNT_JSON`
 - `GOOGLE_SHEETS_SPREADSHEET_ID`
+
+Repository secrets required for the full automated run:
+- `REDDIT_USER_AGENT`
 
 Optional secrets:
 - `OPENAI_API_KEY`
 - `OPENAI_MODEL`
+
+The workflow authenticates to Google with `google-github-actions/auth` using
+GitHub OIDC and short-lived credentials. It no longer requires
+`GOOGLE_SERVICE_ACCOUNT_JSON` in GitHub secrets.
 
 On workflow failure, the action uploads `reports/`, `data/processed/`, and
 `data/state/` as an artifact for debugging.

--- a/tests/test_github_actions_workflow.py
+++ b/tests/test_github_actions_workflow.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def load_workflow() -> dict[str, object]:
+    path = Path.cwd() / ".github" / "workflows" / "daily-digest.yml"
+    return yaml.safe_load(path.read_text())
+
+
+def workflow_triggers(workflow: dict[str, object]) -> dict[str, object]:
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict)
+    return triggers
+
+
+def test_daily_workflow_uses_oidc_for_google_auth() -> None:
+    workflow = load_workflow()
+    job = workflow["jobs"]["run-digest"]
+    permissions = job["permissions"]
+    env = job["env"]
+    steps = job["steps"]
+
+    assert permissions == {"contents": "read", "id-token": "write"}
+    assert env["GOOGLE_SHEETS_SPREADSHEET_ID"] == "${{ vars.GOOGLE_SHEETS_SPREADSHEET_ID }}"
+    assert "GOOGLE_SERVICE_ACCOUNT_JSON" not in env
+
+    auth_step = next(step for step in steps if step.get("uses") == "google-github-actions/auth@v3")
+    assert auth_step["with"] == {
+        "workload_identity_provider": "${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}",
+        "service_account": "${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}",
+        "create_credentials_file": True,
+        "export_environment_variables": True,
+    }
+
+
+def test_daily_workflow_remains_manually_runnable() -> None:
+    workflow = load_workflow()
+
+    assert "workflow_dispatch" in workflow_triggers(workflow)


### PR DESCRIPTION
## Summary
- switch the GitHub Actions workflow from a Google service account JSON secret to GitHub OIDC with `google-github-actions/auth`
- parameterize the Google auth inputs from repository variables and keep the pipeline manually runnable
- add a workflow contract test and ignore generated `gha-creds-*.json` files

## Testing
- `uv run pytest`

Closes #35.
