### PR TITLE
Align Google auth docs with WIF workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,11 @@
 REDDIT_USER_AGENT=reddit-ai-agents-digest/0.1.0
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-5-mini
+
+# GitHub Actions repository variables for Google Sheets via WIF/OIDC
 GCP_WORKLOAD_IDENTITY_PROVIDER=
 GCP_SERVICE_ACCOUNT_EMAIL=
-GOOGLE_SERVICE_ACCOUNT_JSON=
 GOOGLE_SHEETS_SPREADSHEET_ID=
+
+# Local-only fallback if ADC is unavailable
+# GOOGLE_SERVICE_ACCOUNT_JSON=

--- a/README.md
+++ b/README.md
@@ -38,14 +38,27 @@ uv run pytest
 Copy `.env.example` to `.env` for local reference, then export the values in your
 shell or load them with your preferred environment tool before running commands.
 
-Key runtime environment variables:
+Core runtime environment variables:
+- `REDDIT_USER_AGENT`
+- `GOOGLE_SHEETS_SPREADSHEET_ID`
+
+Optional runtime environment variables:
+- `OPENAI_API_KEY`
+- `OPENAI_MODEL`
+
+Google Sheets authentication for local runs can come from:
+- Application Default Credentials
+- `GOOGLE_SERVICE_ACCOUNT_JSON` as a backward-compatible local fallback
+
+GitHub Actions repository variables for Sheets:
+- `GCP_WORKLOAD_IDENTITY_PROVIDER`
+- `GCP_SERVICE_ACCOUNT_EMAIL`
+- `GOOGLE_SHEETS_SPREADSHEET_ID`
+
+GitHub Actions secrets:
 - `REDDIT_USER_AGENT`
 - `OPENAI_API_KEY`
 - `OPENAI_MODEL`
-- `GCP_WORKLOAD_IDENTITY_PROVIDER`
-- `GCP_SERVICE_ACCOUNT_EMAIL`
-- `GOOGLE_SERVICE_ACCOUNT_JSON`
-- `GOOGLE_SHEETS_SPREADSHEET_ID`
 
 Supported runtime overrides:
 - `INCLUDE_SECONDARY_SUBREDDITS`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,12 +62,15 @@ src/reddit_digest/
 - The OpenAI step is advisory only. It can influence `Watch Next`, but it does
   not create same-day Reddit findings.
 - MVP ingestion uses public Reddit JSON endpoints and only requires a user agent.
+- GitHub Actions authenticates to Google Sheets via GitHub OIDC and Workload
+  Identity Federation; local runs can still use ADC or a local JSON fallback.
 - Google Sheets export is idempotent by `run_date`.
 - Re-running the same date overwrites file outputs and state rather than
   creating duplicates.
 
 ## Current gaps
 
-- GitHub Actions automation is not yet added.
 - There is no long-term trend analysis beyond the most recent prior run.
 - The OpenAI suggestion schema is prompt-based JSON rather than strict schema enforcement.
+- The GCP-side Workload Identity Federation setup still has to be provisioned
+  outside the repository.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -10,7 +10,7 @@ Required environment variables for the full pipeline:
 - `REDDIT_USER_AGENT`
 - `GOOGLE_SHEETS_SPREADSHEET_ID`
 
-Google authentication for Sheets can come from either:
+Google authentication for local Sheets export can come from either:
 - ambient Application Default Credentials, including Workload Identity Federation in CI
 - `GOOGLE_SERVICE_ACCOUNT_JSON` as a backward-compatible local fallback
 

--- a/tests/test_google_auth_docs.py
+++ b/tests/test_google_auth_docs.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_env_example_prefers_wif_variables_over_json_key() -> None:
+    lines = (Path.cwd() / ".env.example").read_text().splitlines()
+
+    assert "GCP_WORKLOAD_IDENTITY_PROVIDER=" in lines
+    assert "GCP_SERVICE_ACCOUNT_EMAIL=" in lines
+    assert "GOOGLE_SHEETS_SPREADSHEET_ID=" in lines
+    assert "# GOOGLE_SERVICE_ACCOUNT_JSON=" in lines
+    assert "GOOGLE_SERVICE_ACCOUNT_JSON=" not in [line for line in lines if not line.startswith("#")]
+
+
+def test_google_auth_docs_match_current_workflow_model() -> None:
+    readme = (Path.cwd() / "README.md").read_text()
+    operations = (Path.cwd() / "docs" / "operations.md").read_text()
+    architecture = (Path.cwd() / "docs" / "architecture.md").read_text()
+
+    assert "GitHub Actions repository variables for Sheets" in readme
+    assert "GCP_WORKLOAD_IDENTITY_PROVIDER" in readme
+    assert "GOOGLE_SERVICE_ACCOUNT_JSON" in readme
+    assert "Repository variables required for the GitHub Actions Sheets path" in operations
+    assert "GOOGLE_SERVICE_ACCOUNT_JSON` in GitHub secrets" in operations
+    assert "GitHub Actions automation is not yet added." not in architecture


### PR DESCRIPTION
## Summary
- rewrite `.env.example`, README, and operations guidance so WIF/OIDC is the primary GitHub Actions setup
- clearly mark `GOOGLE_SERVICE_ACCOUNT_JSON` as a local-only fallback instead of a normal CI input
- add docs consistency tests and refresh the architecture note that was still claiming Actions were missing

## Testing
- `uv run pytest`

Closes #37.
