### PR TITLE
Validate Sheets auth with WIF-backed credentials

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -14,6 +14,11 @@ Google authentication for local Sheets export can come from either:
 - ambient Application Default Credentials, including Workload Identity Federation in CI
 - `GOOGLE_SERVICE_ACCOUNT_JSON` as a backward-compatible local fallback
 
+Local development differs from CI:
+- CI gets short-lived Google credentials from GitHub OIDC and Workload Identity Federation.
+- Local runs should use Application Default Credentials first, for example via `gcloud auth application-default login`.
+- `GOOGLE_SERVICE_ACCOUNT_JSON` is only a local fallback when ADC is not available.
+
 Optional environment variables:
 - `OPENAI_API_KEY`
 - `OPENAI_MODEL`

--- a/src/reddit_digest/outputs/google_sheets.py
+++ b/src/reddit_digest/outputs/google_sheets.py
@@ -115,6 +115,7 @@ class GoogleSheetsExporter:
 
 def load_google_sheets_credentials(runtime: RuntimeConfig) -> Credentials:
     if runtime.google_service_account_json:
+        LOGGER.info("Using GOOGLE_SERVICE_ACCOUNT_JSON fallback for Google Sheets auth")
         try:
             credentials_info = json.loads(runtime.google_service_account_json)
         except json.JSONDecodeError as exc:
@@ -124,6 +125,7 @@ def load_google_sheets_credentials(runtime: RuntimeConfig) -> Credentials:
             scopes=list(GOOGLE_SHEETS_SCOPES),
         )
 
+    LOGGER.info("Using Application Default Credentials for Google Sheets auth")
     credentials, _ = google.auth.default(scopes=list(GOOGLE_SHEETS_SCOPES))
     return credentials
 

--- a/tests/test_google_sheets.py
+++ b/tests/test_google_sheets.py
@@ -197,6 +197,13 @@ def test_load_google_sheets_credentials_uses_application_default_credentials(mon
     assert credentials == "adc-creds"
 
 
+def test_load_google_sheets_credentials_rejects_invalid_json() -> None:
+    runtime = build_runtime(google_service_account_json="{not-json}")
+
+    with pytest.raises(ValueError, match="GOOGLE_SERVICE_ACCOUNT_JSON"):
+        load_google_sheets_credentials(runtime)
+
+
 def test_google_sheets_exporter_from_runtime_uses_loaded_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
     workbook = FakeWorkbook()
     client = FakeClient(workbook)
@@ -214,3 +221,29 @@ def test_google_sheets_exporter_from_runtime_uses_loaded_credentials(monkeypatch
 
     assert isinstance(exporter, GoogleSheetsExporter)
     assert client.opened_key == "sheet-123"
+
+
+def test_google_sheets_exporter_from_runtime_supports_wif_backed_adc(monkeypatch: pytest.MonkeyPatch) -> None:
+    workbook = FakeWorkbook()
+    client = FakeClient(workbook)
+    captured: dict[str, object] = {}
+    runtime = build_runtime(
+        gcp_workload_identity_provider="projects/123/locations/global/workloadIdentityPools/pool/providers/provider",
+        gcp_service_account_email="digest-bot@example.iam.gserviceaccount.com",
+    )
+
+    def fake_default(*, scopes: list[str]) -> tuple[str, str]:
+        captured["scopes"] = scopes
+        return "adc-creds", "project-id"
+
+    monkeypatch.setattr("reddit_digest.outputs.google_sheets.google.auth.default", fake_default)
+    monkeypatch.setattr(
+        "reddit_digest.outputs.google_sheets.gspread.authorize",
+        lambda credentials: client if credentials == "adc-creds" else None,
+    )
+
+    exporter = GoogleSheetsExporter.from_runtime(runtime)
+
+    assert isinstance(exporter, GoogleSheetsExporter)
+    assert client.opened_key == "sheet-123"
+    assert captured["scopes"] == ["https://www.googleapis.com/auth/spreadsheets"]


### PR DESCRIPTION
## Summary
- add explicit validation for the WIF/ADC-backed Sheets auth path and the legacy JSON failure path
- add auth-source logging in the Sheets exporter for easier runtime diagnosis
- document the local-vs-CI difference so operators know when ADC vs JSON fallback is expected

## Testing
- `uv run pytest`

Closes #38.
