### PR TITLE
Run markdown workflow on self-hosted runners

### DIFF
--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   run-digest:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 30
     env:
       REDDIT_USER_AGENT: ${{ vars.REDDIT_USER_AGENT }}
@@ -29,7 +29,7 @@ jobs:
         run: uv sync --dev
 
       - name: Run daily digest pipeline
-        run: uv run reddit-digest run-daily --skip-sheets
+        run: make run-markdown
 
       - name: Upload pipeline artifacts on failure
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test lint run
+.PHONY: install test lint run run-markdown
 
 install:
 	uv sync
@@ -11,3 +11,6 @@ lint:
 
 run:
 	uv run reddit-digest --help
+
+run-markdown:
+	uv run reddit-digest run-daily --skip-sheets

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ uv run reddit-digest --help
 Run the full daily pipeline locally without Sheets export:
 
 ```bash
-uv run reddit-digest run-daily --date 2026-03-12 --skip-sheets
+make run-markdown
 ```
 
 Run tests:
@@ -80,10 +80,17 @@ Default Credentials, including Workload Identity Federation in CI. The existing
 `GOOGLE_SERVICE_ACCOUNT_JSON` input remains a backward-compatible local
 fallback.
 
-The GitHub Actions workflow currently runs the markdown pipeline only with
+The supported automated execution path is now a GitHub Actions `self-hosted`
+runner or a direct local run on the same machine. GitHub-hosted runners are not
+supported for live Reddit collection because Reddit blocks the public JSON
+requests from those runner IPs. The canonical markdown-only command is
+`make run-markdown`.
+
+The self-hosted GitHub Actions workflow runs the markdown pipeline only with
 `--skip-sheets`, so it does not require Google credentials. When you want to
-re-enable Google Sheets export in CI, use the setup runbook in
+re-enable Google Sheets export in self-hosted CI, use the setup runbook in
 [`docs/gcp-wif-setup.md`](docs/gcp-wif-setup.md).
+Google Sheets export in CI is currently disabled by design.
 
 ## Repository layout
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -34,7 +34,7 @@ Optional environment variables:
 Run the full pipeline without Sheets export:
 
 ```bash
-uv run reddit-digest run-daily --date 2026-03-12 --skip-sheets
+make run-markdown
 ```
 
 Run the full pipeline including Sheets export:
@@ -70,6 +70,7 @@ It supports:
 - daily scheduled runs at `07:00 UTC`
 - manual dispatch from the GitHub Actions UI
 - markdown generation without Google Sheets export
+- execution on a `self-hosted` runner only
 
 Repository secrets required for the full automated run:
 - `REDDIT_USER_AGENT`
@@ -78,10 +79,15 @@ Optional secrets:
 - `OPENAI_API_KEY`
 - `OPENAI_MODEL`
 
-The workflow currently runs `uv run reddit-digest run-daily --skip-sheets`, so
-Google auth is not required in CI. If you later want Sheets export in GitHub
-Actions, use the runbook in [`docs/gcp-wif-setup.md`](gcp-wif-setup.md) and
-reintroduce the OIDC auth step.
+GitHub-hosted runners are not supported for live Reddit collection because
+Reddit blocks the public JSON requests from those runner networks. The workflow
+therefore runs only on a `self-hosted` runner and uses the same canonical local
+command as manual execution: `make run-markdown`.
+
+The workflow currently runs markdown-only, so Google auth is not required in
+CI. Google auth is not required in CI for the current markdown-only workflow.
+If you later want Sheets export in self-hosted CI, use the runbook in
+[`docs/gcp-wif-setup.md`](gcp-wif-setup.md) and reintroduce the OIDC auth step.
 
 On workflow failure, the action uploads `reports/`, `data/processed/`, and
 `data/state/` as an artifact for debugging.

--- a/tests/test_github_actions_workflow.py
+++ b/tests/test_github_actions_workflow.py
@@ -22,6 +22,7 @@ def test_daily_workflow_runs_markdown_without_google_auth() -> None:
     env = job["env"]
     steps = job["steps"]
 
+    assert job["runs-on"] == "self-hosted"
     assert "permissions" not in job
     assert env["REDDIT_USER_AGENT"] == "${{ vars.REDDIT_USER_AGENT }}"
     assert env["OPENAI_MODEL"] == "${{ vars.OPENAI_MODEL }}"
@@ -31,7 +32,7 @@ def test_daily_workflow_runs_markdown_without_google_auth() -> None:
     assert all(step.get("uses") != "google-github-actions/auth@v3" for step in steps)
 
     run_step = next(step for step in steps if step.get("name") == "Run daily digest pipeline")
-    assert run_step["run"] == "uv run reddit-digest run-daily --skip-sheets"
+    assert run_step["run"] == "make run-markdown"
 
 
 def test_daily_workflow_remains_manually_runnable() -> None:


### PR DESCRIPTION
## Summary
- move the markdown-only GitHub workflow to `self-hosted`
- add `make run-markdown` as the canonical local and workflow command
- update docs and workflow tests to reflect the supported execution model

## Testing
- `uv run pytest`

Closes #44.
