### PR TITLE
Add ranked thread selection service

### DIFF
--- a/src/reddit_digest/outputs/markdown.py
+++ b/src/reddit_digest/outputs/markdown.py
@@ -4,15 +4,13 @@ from __future__ import annotations
 
 from collections import Counter
 from dataclasses import dataclass
-from datetime import UTC
-from datetime import datetime
 from pathlib import Path
 
 from reddit_digest.config import ScoringConfig
 from reddit_digest.models.insight import Insight
-from reddit_digest.models.post import Post
 from reddit_digest.ranking.impact import score_insight
-from reddit_digest.ranking.impact import score_post
+from reddit_digest.ranking.threads import RankedPost
+from reddit_digest.ranking.threads import ThreadSelection
 
 
 @dataclass(frozen=True)
@@ -25,31 +23,24 @@ class MarkdownDigestResult:
 def render_markdown_digest(
     *,
     run_date: str,
-    posts: tuple[Post, ...],
     insights: tuple[Insight, ...],
     scoring: ScoringConfig,
+    thread_selection: ThreadSelection,
     reports_root: Path,
-    lookback_hours: int,
     watch_next: tuple[str, ...] = (),
-    run_at: datetime | None = None,
 ) -> MarkdownDigestResult:
-    effective_run_at = run_at or datetime.now(tz=UTC)
-    scored_posts = sorted(
-        [(post, score_post(post, scoring, run_at=effective_run_at, lookback_hours=lookback_hours)) for post in posts],
-        key=lambda item: (-item[1].total, item[0].id),
-    )
     scored_insights = sorted(
         [(insight, score_insight(insight, scoring)) for insight in insights],
         key=lambda item: (item[0].category, -item[1].total, item[0].title, item[0].source_id),
     )
 
     lines = [f"# Daily Reddit Digest — {run_date}", ""]
-    lines.extend(_render_executive_summary(scored_posts, scored_insights))
+    lines.extend(_render_executive_summary(thread_selection.ranked_posts, scored_insights))
     lines.extend(_render_insight_section("Top Tools Mentioned", "tools", scored_insights))
     lines.extend(_render_insight_section("Top Approaches / Workflows", "approaches", scored_insights))
     lines.extend(_render_insight_section("Top Guides / Resources", "guides", scored_insights))
     lines.extend(_render_insight_section("Testing and Quality Insights", "testing", scored_insights))
-    lines.extend(_render_notable_threads(scored_posts, scored_insights))
+    lines.extend(_render_notable_threads(thread_selection.notable_threads, scored_insights))
     lines.extend(_render_emerging_themes(scored_insights))
     watch_next_lines = _render_watch_next(watch_next=watch_next, scored_insights=scored_insights)
     if watch_next_lines:
@@ -64,14 +55,14 @@ def render_markdown_digest(
     return MarkdownDigestResult(daily_path=daily_path, latest_path=latest_path, content=content)
 
 
-def _render_executive_summary(scored_posts: list[tuple[Post, object]], scored_insights: list[tuple[Insight, object]]) -> list[str]:
-    top_post = scored_posts[0][0] if scored_posts else None
+def _render_executive_summary(ranked_posts: tuple[RankedPost, ...], scored_insights: list[tuple[Insight, object]]) -> list[str]:
+    top_post = ranked_posts[0].post if ranked_posts else None
     top_insights = [insight.title for insight, _ in scored_insights[:2]]
     bullets = [
         "## Executive Summary",
         *(f"- Top thread: {top_post.title}" for _ in [0] if top_post is not None),
         *(f"- Leading insights: {', '.join(top_insights)}" for _ in [0] if top_insights),
-        f"- Total posts analyzed: {len(scored_posts)}",
+        f"- Total posts analyzed: {len(ranked_posts)}",
         f"- Total insights extracted: {len(scored_insights)}",
         "",
     ]
@@ -100,17 +91,17 @@ def _render_insight_section(
 
 
 def _render_notable_threads(
-    scored_posts: list[tuple[Post, object]],
+    ranked_posts: tuple[RankedPost, ...],
     scored_insights: list[tuple[Insight, object]],
 ) -> list[str]:
     lines = ["## Notable Threads"]
-    top_posts = scored_posts[:5]
-    if not top_posts:
+    if not ranked_posts:
         lines.append("- No notable threads today.")
         lines.append("")
         return lines
 
-    for post, breakdown in top_posts:
+    for ranked_post in ranked_posts:
+        post = ranked_post.post
         related = [insight for insight, _ in scored_insights if insight.source_post_id == post.id]
         why_it_matters = related[0].why_it_matters if related and related[0].why_it_matters else "Relevant discussion for AI-assisted development workflows."
         tags = sorted({tag for insight in related for tag in insight.tags})
@@ -119,7 +110,7 @@ def _render_notable_threads(
         lines.append(f"  - Subreddit: r/{post.subreddit}")
         lines.append(f"  - Summary: {summary}")
         lines.append(f"  - Why it matters: {why_it_matters}")
-        lines.append(f"  - Impact score: {breakdown.total:.2f}")
+        lines.append(f"  - Impact score: {ranked_post.breakdown.total:.2f}")
         lines.append(f"  - Extracted tags: {', '.join(tags) if tags else 'none'}")
     lines.append("")
     return lines

--- a/src/reddit_digest/pipeline.py
+++ b/src/reddit_digest/pipeline.py
@@ -19,6 +19,7 @@ from reddit_digest.extractors.service import extract_insights
 from reddit_digest.extractors.openai_suggestions import build_openai_client
 from reddit_digest.extractors.openai_suggestions import generate_suggestions
 from reddit_digest.ranking.novelty import apply_novelty
+from reddit_digest.ranking.threads import select_threads
 from reddit_digest.utils.retries import retry_call
 from reddit_digest.utils.state import RunState
 from reddit_digest.utils.state import write_run_state
@@ -85,15 +86,20 @@ class PipelineRunner:
                 logger=LOGGER,
             )
             suggestions = tuple(f"{item.title}: {item.rationale}" for item in suggestion_result.suggestions)
+        thread_selection = select_threads(
+            post_result.posts,
+            scoring=config.scoring,
+            enabled_subreddits=config.subreddits.enabled_subreddits,
+            run_at=run_at,
+            lookback_hours=config.subreddits.fetch.lookback_hours,
+        )
         markdown = render_markdown_digest(
             run_date=run_date,
-            posts=post_result.posts,
             insights=novelty.insights,
             scoring=config.scoring,
+            thread_selection=thread_selection,
             reports_root=self.base_path / "reports",
-            lookback_hours=config.subreddits.fetch.lookback_hours,
             watch_next=suggestions,
-            run_at=run_at,
         )
 
         sheets_exported = False

--- a/src/reddit_digest/ranking/threads.py
+++ b/src/reddit_digest/ranking/threads.py
@@ -1,0 +1,89 @@
+"""Ranked thread selection for digest rendering."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from reddit_digest.config import ScoringConfig
+from reddit_digest.models.post import Post
+from reddit_digest.ranking.impact import ScoreBreakdown
+from reddit_digest.ranking.impact import score_post
+
+
+@dataclass(frozen=True)
+class RankedPost:
+    post: Post
+    breakdown: ScoreBreakdown
+
+
+@dataclass(frozen=True)
+class SubredditThreadRanking:
+    subreddit: str
+    posts: tuple[RankedPost, ...]
+
+
+@dataclass(frozen=True)
+class ThreadSelection:
+    ranked_posts: tuple[RankedPost, ...]
+    notable_threads: tuple[RankedPost, ...]
+    by_subreddit: tuple[SubredditThreadRanking, ...]
+
+
+def select_threads(
+    posts: tuple[Post, ...],
+    *,
+    scoring: ScoringConfig,
+    enabled_subreddits: tuple[str, ...],
+    run_at: datetime,
+    lookback_hours: int,
+    global_limit: int = 5,
+    per_subreddit_limit: int = 3,
+) -> ThreadSelection:
+    enabled = tuple(dict.fromkeys(enabled_subreddits))
+    enabled_set = set(enabled)
+    ranked_posts = tuple(
+        sorted(
+            (
+                RankedPost(
+                    post=post,
+                    breakdown=score_post(post, scoring, run_at=run_at, lookback_hours=lookback_hours),
+                )
+                for post in posts
+                if post.subreddit in enabled_set
+            ),
+            key=lambda item: (-item.breakdown.total, item.post.subreddit.lower(), item.post.id),
+        )
+    )
+
+    by_subreddit = tuple(
+        SubredditThreadRanking(
+            subreddit=subreddit,
+            posts=tuple(ranked for ranked in ranked_posts if ranked.post.subreddit == subreddit)[:per_subreddit_limit],
+        )
+        for subreddit in enabled
+        if any(ranked.post.subreddit == subreddit for ranked in ranked_posts)
+    )
+
+    return ThreadSelection(
+        ranked_posts=ranked_posts,
+        notable_threads=_select_notable_threads(ranked_posts, limit=global_limit),
+        by_subreddit=by_subreddit,
+    )
+
+
+def _select_notable_threads(ranked_posts: tuple[RankedPost, ...], *, limit: int) -> tuple[RankedPost, ...]:
+    selected = list(ranked_posts[:limit])
+    if len(selected) < 2:
+        return tuple(selected)
+
+    represented = {item.post.subreddit for item in selected}
+    if len(represented) >= 2:
+        return tuple(selected)
+
+    replacement = next((item for item in ranked_posts[limit:] if item.post.subreddit not in represented), None)
+    if replacement is None:
+        return tuple(selected)
+
+    selected[-1] = replacement
+    return tuple(selected)

--- a/tests/test_google_sheets.py
+++ b/tests/test_google_sheets.py
@@ -20,6 +20,7 @@ from reddit_digest.outputs.google_sheets import RAW_POSTS_TAB
 from reddit_digest.outputs.google_sheets import load_google_sheets_credentials
 from reddit_digest.outputs.markdown import render_markdown_digest
 from reddit_digest.ranking.novelty import apply_novelty
+from reddit_digest.ranking.threads import select_threads
 
 
 @dataclass
@@ -71,15 +72,20 @@ def build_inputs(sample_posts_payload: list[dict[str, object]], sample_comments_
     scoring = load_scoring_config(Path.cwd() / "config" / "scoring.yaml")
     extracted = extract_insights(posts, comments, processed_root=tmp_path / "processed", run_date="2026-03-12")
     novelty = apply_novelty(tmp_path / "processed", run_date="2026-03-12", insights=extracted.insights)
+    thread_selection = select_threads(
+        posts,
+        scoring=scoring,
+        enabled_subreddits=("Codex", "ClaudeCode", "Vibecoding"),
+        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+        lookback_hours=24,
+    )
     markdown = render_markdown_digest(
         run_date="2026-03-12",
-        posts=posts,
         insights=novelty.insights,
         scoring=scoring,
+        thread_selection=thread_selection,
         reports_root=tmp_path / "reports",
-        lookback_hours=24,
         watch_next=("Monitor prompt-state snapshots",),
-        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
     )
     return posts, novelty.insights, scoring, markdown.content
 

--- a/tests/test_markdown_output.py
+++ b/tests/test_markdown_output.py
@@ -10,6 +10,7 @@ from reddit_digest.models.comment import Comment
 from reddit_digest.models.post import Post
 from reddit_digest.outputs.markdown import render_markdown_digest
 from reddit_digest.ranking.novelty import apply_novelty
+from reddit_digest.ranking.threads import select_threads
 
 
 def test_render_markdown_digest_writes_daily_and_latest(
@@ -22,15 +23,20 @@ def test_render_markdown_digest_writes_daily_and_latest(
     extracted = extract_insights(posts, comments, processed_root=tmp_path / "processed", run_date="2026-03-12")
     novelty = apply_novelty(tmp_path / "processed", run_date="2026-03-12", insights=extracted.insights)
     scoring = load_scoring_config(Path.cwd() / "config" / "scoring.yaml")
+    thread_selection = select_threads(
+        posts,
+        scoring=scoring,
+        enabled_subreddits=("Codex", "ClaudeCode", "Vibecoding"),
+        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+        lookback_hours=24,
+    )
 
     result = render_markdown_digest(
         run_date="2026-03-12",
-        posts=posts,
         insights=novelty.insights,
         scoring=scoring,
+        thread_selection=thread_selection,
         reports_root=tmp_path / "reports",
-        lookback_hours=24,
-        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
     )
 
     assert result.daily_path.exists()
@@ -52,16 +58,21 @@ def test_markdown_digest_section_order(
     extracted = extract_insights(posts, comments, processed_root=tmp_path / "processed", run_date="2026-03-12")
     novelty = apply_novelty(tmp_path / "processed", run_date="2026-03-12", insights=extracted.insights)
     scoring = load_scoring_config(Path.cwd() / "config" / "scoring.yaml")
+    thread_selection = select_threads(
+        posts,
+        scoring=scoring,
+        enabled_subreddits=("Codex", "ClaudeCode", "Vibecoding"),
+        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+        lookback_hours=24,
+    )
 
     result = render_markdown_digest(
         run_date="2026-03-12",
-        posts=posts,
         insights=novelty.insights,
         scoring=scoring,
+        thread_selection=thread_selection,
         reports_root=tmp_path / "reports",
-        lookback_hours=24,
         watch_next=("Monitor prompt-state snapshots",),
-        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
     )
 
     sections = [

--- a/tests/test_thread_selection.py
+++ b/tests/test_thread_selection.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from datetime import UTC
+from datetime import datetime
+from pathlib import Path
+
+from reddit_digest.config import load_scoring_config
+from reddit_digest.models.post import Post
+from reddit_digest.ranking.threads import select_threads
+
+
+RUN_AT = datetime(2026, 3, 12, 12, 0, tzinfo=UTC)
+
+
+def build_post(
+    *,
+    post_id: str,
+    subreddit: str,
+    title: str,
+    score: int,
+    num_comments: int,
+    created_utc: int = 1_741_780_800,
+) -> Post:
+    return Post.from_raw(
+        {
+            "id": post_id,
+            "subreddit": subreddit,
+            "title": title,
+            "author": "builder",
+            "score": score,
+            "num_comments": num_comments,
+            "created_utc": created_utc,
+            "url": f"https://reddit.com/{post_id}",
+            "permalink": f"/r/{subreddit}/comments/{post_id}",
+            "selftext": "workflow guide eval automation test prompt",
+        }
+    )
+
+
+def test_select_threads_enforces_minimal_subreddit_diversity() -> None:
+    scoring = load_scoring_config(Path.cwd() / "config" / "scoring.yaml")
+    posts = (
+        build_post(post_id="a1", subreddit="Codex", title="Codex 1", score=95, num_comments=28),
+        build_post(post_id="a2", subreddit="Codex", title="Codex 2", score=90, num_comments=24),
+        build_post(post_id="a3", subreddit="Codex", title="Codex 3", score=88, num_comments=22),
+        build_post(post_id="a4", subreddit="Codex", title="Codex 4", score=86, num_comments=20),
+        build_post(post_id="a5", subreddit="Codex", title="Codex 5", score=84, num_comments=18),
+        build_post(post_id="b1", subreddit="ClaudeCode", title="ClaudeCode 1", score=70, num_comments=16),
+    )
+
+    selection = select_threads(
+        posts,
+        scoring=scoring,
+        enabled_subreddits=("Codex", "ClaudeCode"),
+        run_at=RUN_AT,
+        lookback_hours=24,
+    )
+
+    assert len(selection.notable_threads) == 5
+    assert {item.post.subreddit for item in selection.notable_threads} == {"Codex", "ClaudeCode"}
+    assert selection.notable_threads[-1].post.id == "b1"
+
+
+def test_select_threads_uses_only_enabled_subreddits() -> None:
+    scoring = load_scoring_config(Path.cwd() / "config" / "scoring.yaml")
+    posts = (
+        build_post(post_id="a1", subreddit="Codex", title="Codex 1", score=95, num_comments=28),
+        build_post(post_id="b1", subreddit="ClaudeCode", title="ClaudeCode 1", score=90, num_comments=24),
+        build_post(post_id="c1", subreddit="Vibecoding", title="Vibecoding 1", score=92, num_comments=26),
+    )
+
+    selection = select_threads(
+        posts,
+        scoring=scoring,
+        enabled_subreddits=("Codex", "Vibecoding"),
+        run_at=RUN_AT,
+        lookback_hours=24,
+    )
+
+    assert tuple(item.post.subreddit for item in selection.ranked_posts) == ("Codex", "Vibecoding")
+    assert tuple(group.subreddit for group in selection.by_subreddit) == ("Codex", "Vibecoding")
+
+
+def test_select_threads_keeps_single_subreddit_when_no_alternative_exists() -> None:
+    scoring = load_scoring_config(Path.cwd() / "config" / "scoring.yaml")
+    posts = tuple(
+        build_post(post_id=f"a{index}", subreddit="Codex", title=f"Codex {index}", score=100 - index, num_comments=20 - index)
+        for index in range(1, 5)
+    )
+
+    selection = select_threads(
+        posts,
+        scoring=scoring,
+        enabled_subreddits=("Codex", "ClaudeCode"),
+        run_at=RUN_AT,
+        lookback_hours=24,
+    )
+
+    assert len(selection.notable_threads) == 4
+    assert {item.post.subreddit for item in selection.notable_threads} == {"Codex"}
+
+
+def test_select_threads_is_deterministic_for_ties() -> None:
+    scoring = load_scoring_config(Path.cwd() / "config" / "scoring.yaml")
+    posts = (
+        build_post(post_id="b2", subreddit="ClaudeCode", title="same", score=80, num_comments=12),
+        build_post(post_id="a1", subreddit="Codex", title="same", score=80, num_comments=12),
+        build_post(post_id="a2", subreddit="Codex", title="same", score=80, num_comments=12),
+    )
+
+    first = select_threads(
+        posts,
+        scoring=scoring,
+        enabled_subreddits=("Codex", "ClaudeCode"),
+        run_at=RUN_AT,
+        lookback_hours=24,
+    )
+    second = select_threads(
+        posts,
+        scoring=scoring,
+        enabled_subreddits=("Codex", "ClaudeCode"),
+        run_at=RUN_AT,
+        lookback_hours=24,
+    )
+
+    assert tuple(item.post.id for item in first.ranked_posts) == tuple(item.post.id for item in second.ranked_posts)
+    assert tuple(item.post.id for item in first.notable_threads) == tuple(item.post.id for item in second.notable_threads)
+
+
+def test_select_threads_limits_per_subreddit_rankings() -> None:
+    scoring = load_scoring_config(Path.cwd() / "config" / "scoring.yaml")
+    posts = tuple(
+        build_post(post_id=f"a{index}", subreddit="Codex", title=f"Codex {index}", score=120 - index, num_comments=25 - index)
+        for index in range(1, 6)
+    ) + (
+        build_post(post_id="b1", subreddit="ClaudeCode", title="ClaudeCode 1", score=90, num_comments=18),
+    )
+
+    selection = select_threads(
+        posts,
+        scoring=scoring,
+        enabled_subreddits=("Codex", "ClaudeCode"),
+        run_at=RUN_AT,
+        lookback_hours=24,
+    )
+
+    codex_group = next(group for group in selection.by_subreddit if group.subreddit == "Codex")
+    assert len(codex_group.posts) == 3


### PR DESCRIPTION
## Summary
- add a dedicated ranked thread selection service for enabled subreddits
- wire the pipeline and markdown renderer to consume explicit thread selection results
- add regression tests for diversity, deterministic ordering, and enabled-subreddit filtering

Closes #45