### PR TITLE
Render global and subreddit thread rankings

### DIFF
--- a/src/reddit_digest/outputs/markdown.py
+++ b/src/reddit_digest/outputs/markdown.py
@@ -35,12 +35,13 @@ def render_markdown_digest(
     )
 
     lines = [f"# Daily Reddit Digest — {run_date}", ""]
-    lines.extend(_render_executive_summary(thread_selection.ranked_posts, scored_insights))
+    lines.extend(_render_executive_summary(thread_selection, scored_insights))
     lines.extend(_render_insight_section("Top Tools Mentioned", "tools", scored_insights))
     lines.extend(_render_insight_section("Top Approaches / Workflows", "approaches", scored_insights))
     lines.extend(_render_insight_section("Top Guides / Resources", "guides", scored_insights))
     lines.extend(_render_insight_section("Testing and Quality Insights", "testing", scored_insights))
-    lines.extend(_render_notable_threads(thread_selection.notable_threads, scored_insights))
+    lines.extend(_render_notable_threads(thread_selection, scored_insights))
+    lines.extend(_render_threads_by_subreddit(thread_selection, scored_insights))
     lines.extend(_render_emerging_themes(scored_insights))
     watch_next_lines = _render_watch_next(watch_next=watch_next, scored_insights=scored_insights)
     if watch_next_lines:
@@ -55,14 +56,16 @@ def render_markdown_digest(
     return MarkdownDigestResult(daily_path=daily_path, latest_path=latest_path, content=content)
 
 
-def _render_executive_summary(ranked_posts: tuple[RankedPost, ...], scored_insights: list[tuple[Insight, object]]) -> list[str]:
-    top_post = ranked_posts[0].post if ranked_posts else None
+def _render_executive_summary(thread_selection: ThreadSelection, scored_insights: list[tuple[Insight, object]]) -> list[str]:
+    top_post = thread_selection.ranked_posts[0].post if thread_selection.ranked_posts else None
+    represented = tuple(dict.fromkeys(item.post.subreddit for item in thread_selection.notable_threads))
     top_insights = [insight.title for insight, _ in scored_insights[:2]]
     bullets = [
         "## Executive Summary",
-        *(f"- Top thread: {top_post.title}" for _ in [0] if top_post is not None),
+        *(f"- Headline thread: {top_post.title} (r/{top_post.subreddit})" for _ in [0] if top_post is not None),
+        *(f"- Global top threads span {len(represented)} subreddit(s): {', '.join(f'r/{name}' for name in represented)}" for _ in [0] if represented),
         *(f"- Leading insights: {', '.join(top_insights)}" for _ in [0] if top_insights),
-        f"- Total posts analyzed: {len(ranked_posts)}",
+        f"- Total posts analyzed: {len(thread_selection.ranked_posts)}",
         f"- Total insights extracted: {len(scored_insights)}",
         "",
     ]
@@ -91,28 +94,61 @@ def _render_insight_section(
 
 
 def _render_notable_threads(
-    ranked_posts: tuple[RankedPost, ...],
+    thread_selection: ThreadSelection,
     scored_insights: list[tuple[Insight, object]],
 ) -> list[str]:
     lines = ["## Notable Threads"]
-    if not ranked_posts:
+    if not thread_selection.notable_threads:
         lines.append("- No notable threads today.")
         lines.append("")
         return lines
 
-    for ranked_post in ranked_posts:
-        post = ranked_post.post
-        related = [insight for insight, _ in scored_insights if insight.source_post_id == post.id]
-        why_it_matters = related[0].why_it_matters if related and related[0].why_it_matters else "Relevant discussion for AI-assisted development workflows."
-        tags = sorted({tag for insight in related for tag in insight.tags})
-        summary = (post.selftext or post.title).strip()
-        lines.append(f"- [{post.title}]({post.url})")
-        lines.append(f"  - Subreddit: r/{post.subreddit}")
-        lines.append(f"  - Summary: {summary}")
-        lines.append(f"  - Why it matters: {why_it_matters}")
-        lines.append(f"  - Impact score: {ranked_post.breakdown.total:.2f}")
-        lines.append(f"  - Extracted tags: {', '.join(tags) if tags else 'none'}")
+    for ranked_post in thread_selection.notable_threads:
+        lines.extend(_render_thread_details(ranked_post, scored_insights=scored_insights, include_subreddit=True))
     lines.append("")
+    return lines
+
+
+def _render_threads_by_subreddit(
+    thread_selection: ThreadSelection,
+    scored_insights: list[tuple[Insight, object]],
+) -> list[str]:
+    lines = ["## Top Threads By Subreddit"]
+    if not thread_selection.by_subreddit:
+        lines.append("- No subreddit-specific thread rankings today.")
+        lines.append("")
+        return lines
+
+    for group in thread_selection.by_subreddit:
+        lines.append(f"### r/{group.subreddit}")
+        if not group.posts:
+            lines.append("- No notable threads today.")
+            lines.append("")
+            continue
+        for ranked_post in group.posts:
+            lines.extend(_render_thread_details(ranked_post, scored_insights=scored_insights, include_subreddit=False))
+        lines.append("")
+    return lines
+
+
+def _render_thread_details(
+    ranked_post: RankedPost,
+    *,
+    scored_insights: list[tuple[Insight, object]],
+    include_subreddit: bool,
+) -> list[str]:
+    post = ranked_post.post
+    related = [insight for insight, _ in scored_insights if insight.source_post_id == post.id]
+    why_it_matters = related[0].why_it_matters if related and related[0].why_it_matters else "Relevant discussion for AI-assisted development workflows."
+    tags = sorted({tag for insight in related for tag in insight.tags})
+    summary = (post.selftext or post.title).strip()
+    lines = [f"- [{post.title}]({post.url})"]
+    if include_subreddit:
+        lines.append(f"  - Subreddit: r/{post.subreddit}")
+    lines.append(f"  - Summary: {summary}")
+    lines.append(f"  - Why it matters: {why_it_matters}")
+    lines.append(f"  - Impact score: {ranked_post.breakdown.total:.2f}")
+    lines.append(f"  - Extracted tags: {', '.join(tags) if tags else 'none'}")
     return lines
 
 

--- a/tests/fixtures/processed/sample_digest.md
+++ b/tests/fixtures/processed/sample_digest.md
@@ -1,8 +1,9 @@
 # Daily Reddit Digest — 2026-03-12
 
 ## Executive Summary
-- Agents are increasingly being used with repo-local context files and explicit recovery checkpoints.
-- Test-first prompting continues to show up as the most reliable workflow for safe code changes.
+- Headline thread: Codex agent keeps a local context file for every task (r/Codex)
+- Global top threads span 2 subreddit(s): r/Codex, r/ClaudeCode
+- Leading insights: Codex, Test-first refactors
 
 ## Top Tools Mentioned
 - Codex
@@ -34,6 +35,26 @@
   - Summary: practitioners are storing context locally between runs
   - Why it matters: durable context improves iterative agent work
   - Impact score: 8.7
+- [Claude Code workflow for test-first refactors](https://reddit.com/r/ClaudeCode/comments/post_002)
+  - Subreddit: r/ClaudeCode
+  - Summary: extracting fixtures before editing production code improves safety
+  - Why it matters: test-first prompting reduces breakage in agent-assisted changes
+  - Impact score: 8.2
+
+## Top Threads By Subreddit
+### r/Codex
+- [Codex agent keeps a local context file for every task](https://reddit.com/r/Codex/comments/post_001)
+  - Summary: practitioners are storing context locally between runs
+  - Why it matters: durable context improves iterative agent work
+  - Impact score: 8.7
+  - Extracted tags: ai-agents, context-management
+
+### r/ClaudeCode
+- [Claude Code workflow for test-first refactors](https://reddit.com/r/ClaudeCode/comments/post_002)
+  - Summary: extracting fixtures before editing production code improves safety
+  - Why it matters: test-first prompting reduces breakage in agent-assisted changes
+  - Impact score: 8.2
+  - Extracted tags: testing, workflow
 
 ## Emerging Themes
 - More teams are treating prompt stability as a testing problem.

--- a/tests/test_markdown_contract.py
+++ b/tests/test_markdown_contract.py
@@ -8,6 +8,7 @@ EXPECTED_SECTIONS = [
     "## Top Guides / Resources",
     "## Testing and Quality Insights",
     "## Notable Threads",
+    "## Top Threads By Subreddit",
     "## Emerging Themes",
 ]
 

--- a/tests/test_markdown_output.py
+++ b/tests/test_markdown_output.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from reddit_digest.config import load_scoring_config
 from reddit_digest.extractors.service import extract_insights
 from reddit_digest.models.comment import Comment
+from reddit_digest.models.insight import Insight
 from reddit_digest.models.post import Post
 from reddit_digest.outputs.markdown import render_markdown_digest
 from reddit_digest.ranking.novelty import apply_novelty
@@ -45,6 +46,7 @@ def test_render_markdown_digest_writes_daily_and_latest(
     assert "## Executive Summary" in result.content
     assert "## Top Tools Mentioned" in result.content
     assert "## Notable Threads" in result.content
+    assert "## Top Threads By Subreddit" in result.content
     assert "## Emerging Themes" in result.content
 
 
@@ -82,8 +84,88 @@ def test_markdown_digest_section_order(
         "## Top Guides / Resources",
         "## Testing and Quality Insights",
         "## Notable Threads",
+        "## Top Threads By Subreddit",
         "## Emerging Themes",
         "## Watch Next",
     ]
     positions = [result.content.index(section) for section in sections]
     assert positions == sorted(positions)
+
+
+def test_markdown_digest_renders_global_top_five_and_per_subreddit_top_three(tmp_path: Path) -> None:
+    scoring = load_scoring_config(Path.cwd() / "config" / "scoring.yaml")
+    posts = tuple(
+        _build_post(post_id=f"codex-{index}", subreddit="Codex", score=120 - index, num_comments=30 - index)
+        for index in range(1, 6)
+    ) + tuple(
+        _build_post(post_id=f"claude-{index}", subreddit="ClaudeCode", score=90 - index, num_comments=20 - index)
+        for index in range(1, 5)
+    )
+    insights = tuple(_build_insight(post) for post in posts)
+    thread_selection = select_threads(
+        posts,
+        scoring=scoring,
+        enabled_subreddits=("Codex", "ClaudeCode"),
+        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+        lookback_hours=24,
+    )
+
+    result = render_markdown_digest(
+        run_date="2026-03-12",
+        insights=insights,
+        scoring=scoring,
+        thread_selection=thread_selection,
+        reports_root=tmp_path / "reports",
+    )
+
+    notable_lines = _section_lines(result.content, "## Notable Threads", "## Top Threads By Subreddit")
+    assert notable_lines.count("- [") == 5
+    assert "Global top threads span 2 subreddit(s): r/Codex, r/ClaudeCode" in result.content
+
+    by_subreddit_lines = _section_lines(result.content, "## Top Threads By Subreddit", "## Emerging Themes")
+    assert by_subreddit_lines.count("### r/Codex") == 1
+    assert by_subreddit_lines.count("### r/ClaudeCode") == 1
+
+    codex_section = by_subreddit_lines.split("### r/Codex\n", maxsplit=1)[1].split("### r/ClaudeCode\n", maxsplit=1)[0]
+    claude_section = by_subreddit_lines.split("### r/ClaudeCode\n", maxsplit=1)[1]
+    assert codex_section.count("- [") == 3
+    assert claude_section.count("- [") == 3
+
+
+def _build_post(*, post_id: str, subreddit: str, score: int, num_comments: int) -> Post:
+    return Post.from_raw(
+        {
+            "id": post_id,
+            "subreddit": subreddit,
+            "title": f"{subreddit} thread {post_id}",
+            "author": "tester",
+            "score": score,
+            "num_comments": num_comments,
+            "created_utc": 1_773_316_800,
+            "url": f"https://reddit.com/r/{subreddit}/comments/{post_id}",
+            "permalink": f"/r/{subreddit}/comments/{post_id}",
+            "selftext": "workflow guide eval automation test prompt",
+        }
+    )
+
+
+def _build_insight(post: Post) -> Insight:
+    return Insight.from_raw(
+        {
+            "category": "approaches",
+            "title": f"{post.subreddit} insight {post.id}",
+            "summary": f"{post.title} contains workflow guidance.",
+            "tags": ["workflow", "testing"],
+            "evidence": f"Evidence from {post.id}",
+            "source_kind": "post",
+            "source_id": post.id,
+            "source_post_id": post.id,
+            "source_permalink": post.url,
+            "subreddit": post.subreddit,
+            "why_it_matters": f"{post.subreddit} guidance stays actionable.",
+        }
+    )
+
+
+def _section_lines(content: str, start_heading: str, end_heading: str) -> str:
+    return content.split(start_heading + "\n", maxsplit=1)[1].split("\n" + end_heading, maxsplit=1)[0]


### PR DESCRIPTION
## Summary
- update the digest to show a diversified global notable-thread list and per-subreddit top thread groups
- refresh the executive summary wording so it reports subreddit coverage in the global ranking
- extend markdown tests and the sample digest fixture to cover the new section layout

Closes #46