### PR TITLE
Update self-hosted and ranking docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Run the package entrypoint:
 uv run reddit-digest --help
 ```
 
-Run the full daily pipeline locally without Sheets export:
+Run the markdown-only digest locally:
 
 ```bash
 make run-markdown
@@ -38,8 +38,10 @@ uv run pytest
 Copy `.env.example` to `.env` for local reference, then export the values in your
 shell or load them with your preferred environment tool before running commands.
 
-Core runtime environment variables:
+Required environment variables for local markdown-only runs:
 - `REDDIT_USER_AGENT`
+
+Additional environment variables for local Sheets export:
 - `GOOGLE_SHEETS_SPREADSHEET_ID`
 
 Optional runtime environment variables:
@@ -50,15 +52,17 @@ Google Sheets authentication for local runs can come from:
 - Application Default Credentials
 - `GOOGLE_SERVICE_ACCOUNT_JSON` as a backward-compatible local fallback
 
-GitHub Actions repository variables for Sheets:
+GitHub Actions repository variables for the current markdown-only workflow:
+- `REDDIT_USER_AGENT`
+- `OPENAI_MODEL`
+
+GitHub Actions repository variables for future Sheets export:
 - `GCP_WORKLOAD_IDENTITY_PROVIDER`
 - `GCP_SERVICE_ACCOUNT_EMAIL`
 - `GOOGLE_SHEETS_SPREADSHEET_ID`
 
 GitHub Actions secrets:
-- `REDDIT_USER_AGENT`
 - `OPENAI_API_KEY`
-- `OPENAI_MODEL`
 
 Supported runtime overrides:
 - `INCLUDE_SECONDARY_SUBREDDITS`
@@ -91,6 +95,22 @@ The self-hosted GitHub Actions workflow runs the markdown pipeline only with
 re-enable Google Sheets export in self-hosted CI, use the setup runbook in
 [`docs/gcp-wif-setup.md`](docs/gcp-wif-setup.md).
 Google Sheets export in CI is currently disabled by design.
+
+## Digest ranking behavior
+
+Thread ranking only uses enabled subreddits from `config/subreddits.yaml`.
+Primary subreddits are always included, and secondary subreddits only
+participate when `INCLUDE_SECONDARY_SUBREDDITS=true`.
+
+The digest renders:
+- `## Notable Threads` as a diversified global top 5 across enabled
+  subreddits
+- `## Top Threads By Subreddit` as the top 3 threads for each enabled
+  subreddit
+
+The global top 5 uses the existing deterministic score formula and applies a
+minimal diversity rule: if ranked candidates exist in more than one enabled
+subreddit, the final top 5 will include at least 2 distinct subreddits.
 
 ## Repository layout
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,13 +11,15 @@ artifacts. The runtime flow is:
 4. Extract normalized insights into `data/processed/insights/YYYY-MM-DD.json`.
 5. Compare those insights to the most recent prior run and mark them as `new`
    or `ongoing`.
-6. Optionally generate OpenAI-backed `Watch Next` suggestions into
+6. Rank collected threads across enabled subreddits, producing a diversified
+   global top 5 and per-subreddit top 3 lists.
+7. Optionally generate OpenAI-backed `Watch Next` suggestions into
    `data/processed/suggestions/YYYY-MM-DD.json`.
-7. Render the Markdown digest to `reports/daily/YYYY-MM-DD.md` and refresh
+8. Render the Markdown digest to `reports/daily/YYYY-MM-DD.md` and refresh
    `reports/latest.md`.
-8. Optionally export raw posts, insights, and daily digest summaries to Google
+9. Optionally export raw posts, insights, and daily digest summaries to Google
    Sheets.
-9. Persist run metadata into `data/state/YYYY-MM-DD.json` and `data/state/latest.json`.
+10. Persist run metadata into `data/state/YYYY-MM-DD.json` and `data/state/latest.json`.
 
 ## Code layout
 
@@ -48,7 +50,8 @@ src/reddit_digest/
 │   └── markdown.py
 ├── ranking/
 │   ├── impact.py
-│   └── novelty.py
+│   ├── novelty.py
+│   └── threads.py
 └── utils/
     ├── logging.py
     ├── retries.py
@@ -62,8 +65,14 @@ src/reddit_digest/
 - The OpenAI step is advisory only. It can influence `Watch Next`, but it does
   not create same-day Reddit findings.
 - MVP ingestion uses public Reddit JSON endpoints and only requires a user agent.
+- Thread ranking uses only enabled subreddits and keeps the existing score
+  formula for both global and per-subreddit ordering.
+- The global `Notable Threads` list applies a minimal diversity rule so it
+  includes at least 2 enabled subreddits when eligible candidates exist.
 - GitHub Actions authenticates to Google Sheets via GitHub OIDC and Workload
   Identity Federation; local runs can still use ADC or a local JSON fallback.
+- The current GitHub Actions workflow is markdown-only on a `self-hosted`
+  runner; GitHub-hosted runners are unsupported for live Reddit collection.
 - Google Sheets export is idempotent by `run_date`.
 - Re-running the same date overwrites file outputs and state rather than
   creating duplicates.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -6,8 +6,10 @@
 uv sync --dev
 ```
 
-Required environment variables for the full pipeline:
+Required environment variables for local markdown-only runs:
 - `REDDIT_USER_AGENT`
+
+Additional environment variables for the full local pipeline:
 - `GOOGLE_SHEETS_SPREADSHEET_ID`
 
 Google authentication for local Sheets export can come from either:
@@ -31,7 +33,7 @@ Optional environment variables:
 
 ## Run locally
 
-Run the full pipeline without Sheets export:
+Run the markdown-only pipeline:
 
 ```bash
 make run-markdown
@@ -55,6 +57,19 @@ uv run reddit-digest run-daily --date 2026-03-12
 - Latest digest: `reports/latest.md`
 - Run state: `data/state/YYYY-MM-DD.json`
 
+## Ranking behavior
+
+- Only enabled subreddits contribute to thread ranking.
+- `INCLUDE_SECONDARY_SUBREDDITS=false` means secondary subreddits do not appear
+  in global or per-subreddit rankings.
+- `## Notable Threads` is the diversified global top 5 across enabled
+  subreddits.
+- `## Top Threads By Subreddit` renders the top 3 ranked threads for each
+  enabled subreddit.
+- The global top 5 keeps the current deterministic score formula and requires
+  at least 2 distinct subreddits when eligible candidates exist across more
+  than one enabled subreddit.
+
 ## Failure handling
 
 - Networked stages retry up to three times.
@@ -72,17 +87,19 @@ It supports:
 - markdown generation without Google Sheets export
 - execution on a `self-hosted` runner only
 
-Repository secrets required for the full automated run:
+Repository variables required for the current workflow:
 - `REDDIT_USER_AGENT`
 
-Optional secrets:
-- `OPENAI_API_KEY`
+Optional repository variables:
 - `OPENAI_MODEL`
 
 GitHub-hosted runners are not supported for live Reddit collection because
 Reddit blocks the public JSON requests from those runner networks. The workflow
 therefore runs only on a `self-hosted` runner and uses the same canonical local
 command as manual execution: `make run-markdown`.
+
+Optional secrets:
+- `OPENAI_API_KEY`
 
 The workflow currently runs markdown-only, so Google auth is not required in
 CI. Google auth is not required in CI for the current markdown-only workflow.


### PR DESCRIPTION
## Summary
- align README and operations guidance with the current self-hosted markdown-only workflow
- document the enabled-subreddit ranking behavior and diversity rule
- refresh the architecture notes to include the explicit thread ranking stage

Closes #47