### PR TITLE
Expand regression coverage for ranking workflow

### DIFF
--- a/tests/test_github_actions_workflow.py
+++ b/tests/test_github_actions_workflow.py
@@ -39,3 +39,16 @@ def test_daily_workflow_remains_manually_runnable() -> None:
     workflow = load_workflow()
 
     assert "workflow_dispatch" in workflow_triggers(workflow)
+
+
+def test_daily_workflow_remains_scheduled_and_uploads_failure_artifacts() -> None:
+    workflow = load_workflow()
+    triggers = workflow_triggers(workflow)
+    job = workflow["jobs"]["run-digest"]
+    upload_step = next(step for step in job["steps"] if step.get("uses") == "actions/upload-artifact@v4")
+
+    assert triggers["schedule"] == [{"cron": "0 7 * * *"}]
+    assert upload_step["if"] == "failure()"
+    assert "reports/" in upload_step["with"]["path"]
+    assert "data/processed/" in upload_step["with"]["path"]
+    assert "data/state/" in upload_step["with"]["path"]

--- a/tests/test_markdown_output.py
+++ b/tests/test_markdown_output.py
@@ -132,6 +132,40 @@ def test_markdown_digest_renders_global_top_five_and_per_subreddit_top_three(tmp
     assert claude_section.count("- [") == 3
 
 
+def test_markdown_digest_is_deterministic_for_same_inputs(tmp_path: Path) -> None:
+    scoring = load_scoring_config(Path.cwd() / "config" / "scoring.yaml")
+    posts = (
+        _build_post(post_id="codex-1", subreddit="Codex", score=99, num_comments=25),
+        _build_post(post_id="claude-1", subreddit="ClaudeCode", score=96, num_comments=23),
+        _build_post(post_id="codex-2", subreddit="Codex", score=92, num_comments=19),
+    )
+    insights = tuple(_build_insight(post) for post in posts)
+    thread_selection = select_threads(
+        posts,
+        scoring=scoring,
+        enabled_subreddits=("Codex", "ClaudeCode"),
+        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+        lookback_hours=24,
+    )
+
+    first = render_markdown_digest(
+        run_date="2026-03-12",
+        insights=insights,
+        scoring=scoring,
+        thread_selection=thread_selection,
+        reports_root=tmp_path / "reports-one",
+    )
+    second = render_markdown_digest(
+        run_date="2026-03-12",
+        insights=insights,
+        scoring=scoring,
+        thread_selection=thread_selection,
+        reports_root=tmp_path / "reports-two",
+    )
+
+    assert first.content == second.content
+
+
 def _build_post(*, post_id: str, subreddit: str, score: int, num_comments: int) -> Post:
     return Post.from_raw(
         {

--- a/tests/test_thread_selection.py
+++ b/tests/test_thread_selection.py
@@ -4,6 +4,8 @@ from datetime import UTC
 from datetime import datetime
 from pathlib import Path
 
+from reddit_digest.config import FetchConfig
+from reddit_digest.config import SubredditConfig
 from reddit_digest.config import load_scoring_config
 from reddit_digest.models.post import Post
 from reddit_digest.ranking.threads import select_threads
@@ -34,6 +36,22 @@ def build_post(
             "permalink": f"/r/{subreddit}/comments/{post_id}",
             "selftext": "workflow guide eval automation test prompt",
         }
+    )
+
+
+def build_subreddit_config(*, include_secondary: bool) -> SubredditConfig:
+    return SubredditConfig(
+        primary=("Codex",),
+        secondary=("ClaudeCode",),
+        include_secondary=include_secondary,
+        fetch=FetchConfig(
+            lookback_hours=24,
+            sort_modes=("new", "top"),
+            min_post_score=0,
+            min_comments=0,
+            max_posts_per_subreddit=10,
+            max_comments_per_post=10,
+        ),
     )
 
 
@@ -146,3 +164,49 @@ def test_select_threads_limits_per_subreddit_rankings() -> None:
 
     codex_group = next(group for group in selection.by_subreddit if group.subreddit == "Codex")
     assert len(codex_group.posts) == 3
+
+
+def test_select_threads_respects_secondary_toggle_from_config() -> None:
+    scoring = load_scoring_config(Path.cwd() / "config" / "scoring.yaml")
+    posts = (
+        build_post(post_id="a1", subreddit="Codex", title="Codex 1", score=95, num_comments=28),
+        build_post(post_id="b1", subreddit="ClaudeCode", title="ClaudeCode 1", score=90, num_comments=24),
+    )
+
+    without_secondary = select_threads(
+        posts,
+        scoring=scoring,
+        enabled_subreddits=build_subreddit_config(include_secondary=False).enabled_subreddits,
+        run_at=RUN_AT,
+        lookback_hours=24,
+    )
+    with_secondary = select_threads(
+        posts,
+        scoring=scoring,
+        enabled_subreddits=build_subreddit_config(include_secondary=True).enabled_subreddits,
+        run_at=RUN_AT,
+        lookback_hours=24,
+    )
+
+    assert tuple(item.post.subreddit for item in without_secondary.ranked_posts) == ("Codex",)
+    assert tuple(item.post.subreddit for item in with_secondary.ranked_posts) == ("Codex", "ClaudeCode")
+
+
+def test_select_threads_handles_fewer_than_five_total_candidates() -> None:
+    scoring = load_scoring_config(Path.cwd() / "config" / "scoring.yaml")
+    posts = (
+        build_post(post_id="a1", subreddit="Codex", title="Codex 1", score=95, num_comments=28),
+        build_post(post_id="a2", subreddit="Codex", title="Codex 2", score=90, num_comments=24),
+        build_post(post_id="b1", subreddit="ClaudeCode", title="ClaudeCode 1", score=85, num_comments=20),
+    )
+
+    selection = select_threads(
+        posts,
+        scoring=scoring,
+        enabled_subreddits=("Codex", "ClaudeCode"),
+        run_at=RUN_AT,
+        lookback_hours=24,
+    )
+
+    assert len(selection.notable_threads) == 3
+    assert {item.post.subreddit for item in selection.notable_threads} == {"Codex", "ClaudeCode"}


### PR DESCRIPTION
## Summary
- add regression coverage for secondary subreddit toggles and fewer-than-five candidate days
- verify markdown rendering stays deterministic for the same ranked inputs
- tighten the self-hosted workflow contract around schedule and failure artifact upload

Closes #48