### PR TITLE
Document dual markdown digest outputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ Primary source subreddits for MVP:
 Primary outputs:
 - Daily Markdown digest in `reports/daily/YYYY-MM-DD.md`
 - Refreshed `reports/latest.md`
+- Optional LLM-enhanced digest in `reports/daily/YYYY-MM-DD.llm.md`
+- Optional refreshed `reports/latest.llm.md`
 - Structured export to Google Sheets
 - Optional OpenAI-generated "watch next" suggestions derived from the day's findings
 
@@ -37,21 +39,23 @@ Primary outputs:
 ## Digest rules
 Each daily digest should include:
 1. Executive summary
-2. Top tools mentioned
-3. Top approaches/workflows
-4. Top guides/resources
-5. Testing and quality insights
-6. Notable Reddit threads
-7. Emerging themes
-8. Optional "watch next" section
+2. Picked topics
+3. Emerging themes
+4. Optional "watch next" section
 
-For every notable item include:
+For every picked topic include:
 - title
-- subreddit
-- permalink
-- why it matters
+- executive summary
+- relevance for you
+- original post link
+- source subreddit
+- supporting thread count
 - impact score
-- extracted tags
+
+If the LLM-enhanced digest is generated:
+- it must use the same selected topics as the deterministic digest
+- it may only rewrite topic prose
+- it must not change topic titles, links, source subreddit attribution, scores, or counts
 
 ## Scoring guidance
 Prioritize:
@@ -71,6 +75,7 @@ Treat these as high priority:
 - silently swallowed exceptions
 - incorrect subreddit filtering
 - malformed Markdown digest structure
+- LLM rewriting that changes deterministic topic selection or source attribution
 - secrets leakage risk
 - changes that break deterministic output
 

--- a/README.md
+++ b/README.md
@@ -102,17 +102,30 @@ Thread collection only uses enabled subreddits from `config/subreddits.yaml`.
 Primary subreddits are always included, and secondary subreddits only
 participate when `INCLUDE_SECONDARY_SUBREDDITS=true`.
 
-The markdown digest is topic-oriented:
+The deterministic markdown digest remains the source of record:
+- `reports/daily/YYYY-MM-DD.md`
+- `reports/latest.md`
+
+When `OPENAI_API_KEY` is available, the pipeline can also write an LLM-enhanced
+variant of the same picked topics:
+- `reports/daily/YYYY-MM-DD.llm.md`
+- `reports/latest.llm.md`
+
+The markdown digest is topic-oriented in both variants:
 - `## Executive Summary` describes the day at a high level
 - `## Picked Topics` lists the top picked topics for the day
 - each topic includes:
   - executive summary
   - relevance for you
   - original post link
+  - source subreddit
+  - supporting thread count
+  - impact score
 
-Topics are derived from scored insights, while subreddit ranking is still used
-behind the scenes to keep source-post selection grounded in the configured
-subreddit set.
+Topic selection stays deterministic. The LLM-enhanced markdown only rewrites the
+prose of already-selected topics into cleaner wording. It does not choose
+topics, links, or source subreddits, and if the rewrite step is unavailable or
+fails the deterministic markdown still completes normally.
 
 ## Repository layout
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,15 +11,20 @@ artifacts. The runtime flow is:
 4. Extract normalized insights into `data/processed/insights/YYYY-MM-DD.json`.
 5. Compare those insights to the most recent prior run and mark them as `new`
    or `ongoing`.
-6. Rank collected threads across enabled subreddits, producing a diversified
-   global top 5 and per-subreddit top 3 lists.
-7. Optionally generate OpenAI-backed `Watch Next` suggestions into
+6. Rank collected threads across enabled subreddits so picked topics stay
+   grounded in configured source posts.
+7. Derive deterministic picked topics from scored insights and ranked posts.
+8. Optionally generate OpenAI-backed `Watch Next` suggestions into
    `data/processed/suggestions/YYYY-MM-DD.json`.
-8. Render the Markdown digest to `reports/daily/YYYY-MM-DD.md` and refresh
-   `reports/latest.md`.
-9. Optionally export raw posts, insights, and daily digest summaries to Google
-   Sheets.
-10. Persist run metadata into `data/state/YYYY-MM-DD.json` and `data/state/latest.json`.
+9. Optionally generate OpenAI-backed topic rewrites into
+   `data/processed/topic_rewrites/YYYY-MM-DD.json`.
+10. Render the deterministic Markdown digest to `reports/daily/YYYY-MM-DD.md`
+    and refresh `reports/latest.md`.
+11. Optionally render an LLM-enhanced digest for the same selected topics to
+    `reports/daily/YYYY-MM-DD.llm.md` and `reports/latest.llm.md`.
+12. Optionally export raw posts, insights, and daily digest summaries to Google
+    Sheets.
+13. Persist run metadata into `data/state/YYYY-MM-DD.json` and `data/state/latest.json`.
 
 ## Code layout
 
@@ -62,13 +67,16 @@ src/reddit_digest/
 
 - Normalized typed models sit between collection and downstream processing.
 - Each stage writes its own output instead of relying on in-memory-only flow.
-- The OpenAI step is advisory only. It can influence `Watch Next`, but it does
-  not create same-day Reddit findings.
+- The deterministic markdown is the source-of-record report for a run.
+- The OpenAI step is advisory only. It can influence `Watch Next` and rewrite
+  topic prose, but it does not create same-day Reddit findings or choose topics.
+- The LLM markdown variant is best-effort and never replaces the deterministic
+  report path in run state.
 - MVP ingestion uses public Reddit JSON endpoints and only requires a user agent.
 - Thread ranking uses only enabled subreddits and keeps the existing score
-  formula for both global and per-subreddit ordering.
-- The global `Notable Threads` list applies a minimal diversity rule so it
-  includes at least 2 enabled subreddits when eligible candidates exist.
+  formula for source-post selection.
+- Picked topics are rendered from scored insights with source links from the
+  ranked enabled-subreddit post set.
 - GitHub Actions authenticates to Google Sheets via GitHub OIDC and Workload
   Identity Federation; local runs can still use ADC or a local JSON fallback.
 - The current GitHub Actions workflow is markdown-only on a `self-hosted`

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -53,27 +53,31 @@ uv run reddit-digest run-daily --date 2026-03-12
 - Processed comments: `data/processed/comments/YYYY-MM-DD.json`
 - Processed insights: `data/processed/insights/YYYY-MM-DD.json`
 - OpenAI suggestions: `data/processed/suggestions/YYYY-MM-DD.json`
-- Daily digest: `reports/daily/YYYY-MM-DD.md`
-- Latest digest: `reports/latest.md`
+- OpenAI topic rewrites: `data/processed/topic_rewrites/YYYY-MM-DD.json`
+- Deterministic daily digest: `reports/daily/YYYY-MM-DD.md`
+- Deterministic latest digest: `reports/latest.md`
+- LLM daily digest: `reports/daily/YYYY-MM-DD.llm.md`
+- LLM latest digest: `reports/latest.llm.md`
 - Run state: `data/state/YYYY-MM-DD.json`
 
 ## Ranking behavior
 
-- Only enabled subreddits contribute to thread ranking.
-- `INCLUDE_SECONDARY_SUBREDDITS=false` means secondary subreddits do not appear
-  in global or per-subreddit rankings.
-- `## Notable Threads` is the diversified global top 5 across enabled
-  subreddits.
-- `## Top Threads By Subreddit` renders the top 3 ranked threads for each
-  enabled subreddit.
-- The global top 5 keeps the current deterministic score formula and requires
-  at least 2 distinct subreddits when eligible candidates exist across more
-  than one enabled subreddit.
+- Only enabled subreddits contribute to thread ranking and topic source
+  grounding.
+- `INCLUDE_SECONDARY_SUBREDDITS=false` means secondary subreddits do not
+  contribute threads or source posts.
+- Topic selection is deterministic and derived from scored insights.
+- The deterministic markdown and the LLM markdown use the same selected topics.
+- The LLM variant only rewrites `Picked Topics` prose. It does not change topic
+  titles, links, subreddit attribution, scores, or counts.
 
 ## Failure handling
 
 - Networked stages retry up to three times.
 - Same-day reruns overwrite file outputs deterministically.
+- The deterministic markdown remains the source-of-record output for each run.
+- The LLM markdown variant is best-effort; if topic rewriting fails, the
+  deterministic markdown and run state still complete.
 - Sheets export replaces existing rows for the same `run_date`.
 - The latest completed state is mirrored into `data/state/latest.json`.
 
@@ -101,9 +105,11 @@ command as manual execution: `make run-markdown`.
 Optional secrets:
 - `OPENAI_API_KEY`
 
-The workflow currently runs markdown-only, so Google auth is not required in
-CI. Google auth is not required in CI for the current markdown-only workflow.
-If you later want Sheets export in self-hosted CI, use the runbook in
+The workflow currently runs markdown-only, so Google auth is not required in CI
+for the current markdown-only workflow. If `OPENAI_API_KEY` is present, the
+workflow can emit both markdown variants; otherwise it emits only the
+deterministic markdown. If you later want Sheets export in self-hosted CI, use
+the runbook in
 [`docs/gcp-wif-setup.md`](gcp-wif-setup.md) and reintroduce the OIDC auth step.
 
 On workflow failure, the action uploads `reports/`, `data/processed/`, and

--- a/tests/test_markdown_docs.py
+++ b/tests/test_markdown_docs.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_docs_describe_dual_markdown_outputs() -> None:
+    readme = (Path.cwd() / "README.md").read_text()
+    operations = (Path.cwd() / "docs" / "operations.md").read_text()
+    architecture = (Path.cwd() / "docs" / "architecture.md").read_text()
+    agents = (Path.cwd() / "AGENTS.md").read_text()
+
+    assert "reports/daily/YYYY-MM-DD.llm.md" in readme
+    assert "source of record" in readme
+    assert "reports/latest.llm.md" in operations
+    assert "data/processed/topic_rewrites/YYYY-MM-DD.json" in operations
+    assert "same selected topics" in operations
+    assert "reports/latest.llm.md" in architecture
+    assert "does not create same-day Reddit findings or choose topics" in architecture
+    assert "Optional LLM-enhanced digest" in agents
+    assert "it may only rewrite topic prose" in agents


### PR DESCRIPTION
## Summary
- document the deterministic markdown as the source-of-record output
- add the optional `*.llm.md` report paths and topic rewrite artifact paths to the operator docs
- align `AGENTS.md` with the topic-oriented dual-output digest contract

## Testing
- uv run pytest

Closes #55