### PR TITLE
Enforce structured OpenAI rewrite coverage

### DIFF
--- a/src/reddit_digest/extractors/openai_suggestions.py
+++ b/src/reddit_digest/extractors/openai_suggestions.py
@@ -16,6 +16,10 @@ from reddit_digest.models.post import Post
 from reddit_digest.models.suggestion import Suggestion
 
 
+class OpenAIResponseError(ValueError):
+    """Raised when the OpenAI response does not satisfy the expected schema."""
+
+
 class ResponsesClient(Protocol):
     def create(self, **kwargs: Any) -> Any:
         ...
@@ -91,8 +95,8 @@ def generate_suggestions(
         model=model,
         input=prompt,
     )
-    parsed = json.loads(response.output_text)
-    suggestions = tuple(Suggestion.from_raw(item) for item in parsed.get("suggestions", []))
+    items = _parse_response_items(response.output_text, list_key="suggestions")
+    suggestions = tuple(Suggestion.from_raw(item) for item in items)
 
     path = processed_root / "suggestions" / f"{run_date}.json"
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -121,8 +125,9 @@ def generate_topic_rewrites(
         model=model,
         input=prompt,
     )
-    parsed = json.loads(response.output_text)
-    rewrites = tuple(TopicRewrite.from_raw(item) for item in parsed.get("topic_rewrites", []))
+    items = _parse_response_items(response.output_text, list_key="topic_rewrites")
+    rewrites = tuple(TopicRewrite.from_raw(item) for item in items)
+    _validate_topic_rewrites(rewrites, topics=topics)
 
     path = processed_root / "topic_rewrites" / f"{run_date}.json"
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -141,3 +146,55 @@ def generate_topic_rewrites(
         )
     )
     return TopicRewriteResult(path=path, rewrites=rewrites)
+
+
+def _parse_response_items(output_text: str, *, list_key: str) -> list[dict[str, Any]]:
+    try:
+        parsed = json.loads(output_text)
+    except json.JSONDecodeError as exc:
+        raise OpenAIResponseError("OpenAI response must be valid JSON") from exc
+    if not isinstance(parsed, dict):
+        raise OpenAIResponseError("OpenAI response must be a JSON object")
+    items = parsed.get(list_key)
+    if not isinstance(items, list):
+        raise OpenAIResponseError(f"OpenAI response must include a '{list_key}' list")
+    for index, item in enumerate(items):
+        if not isinstance(item, dict):
+            raise OpenAIResponseError(f"OpenAI response item {index} in '{list_key}' must be an object")
+    return items
+
+
+def _validate_topic_rewrites(
+    rewrites: tuple[TopicRewrite, ...],
+    *,
+    topics: tuple[dict[str, object], ...],
+) -> None:
+    expected_keys = []
+    for topic in topics:
+        topic_key = topic.get("topic_key")
+        if not isinstance(topic_key, str) or not topic_key:
+            raise OpenAIResponseError("Each topic must include a non-empty string 'topic_key'")
+        expected_keys.append(topic_key)
+
+    actual_keys = [item.topic_key for item in rewrites]
+    duplicate_keys = sorted({key for key in actual_keys if actual_keys.count(key) > 1})
+    if duplicate_keys:
+        raise OpenAIResponseError(
+            f"OpenAI topic rewrites contain duplicate topic_key values: {', '.join(duplicate_keys)}"
+        )
+
+    expected_key_set = set(expected_keys)
+    actual_key_set = set(actual_keys)
+    missing = sorted(expected_key_set - actual_key_set)
+    extra = sorted(actual_key_set - expected_key_set)
+    if missing or extra:
+        details: list[str] = []
+        if missing:
+            details.append(f"missing: {', '.join(missing)}")
+        if extra:
+            details.append(f"unexpected: {', '.join(extra)}")
+        raise OpenAIResponseError(
+            "OpenAI topic rewrites must exactly cover the deterministic topic set ("
+            + "; ".join(details)
+            + ")"
+        )

--- a/tests/test_openai_suggestions.py
+++ b/tests/test_openai_suggestions.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from pathlib import Path
 import json
 
+import pytest
+
+from reddit_digest.extractors.openai_suggestions import OpenAIResponseError
 from reddit_digest.extractors.openai_suggestions import generate_suggestions
 from reddit_digest.extractors.openai_suggestions import generate_topic_rewrites
 from reddit_digest.models.insight import Insight
@@ -10,57 +13,91 @@ from reddit_digest.models.post import Post
 
 
 class FakeResponses:
+    def __init__(self, output_text: str) -> None:
+        self.output_text = output_text
+
     def create(self, **kwargs):
         class Response:
-            output_text = json.dumps(
-                {
-                    "suggestions": [
-                        {
-                            "category": "content",
-                            "title": "Prompt-state snapshots",
-                            "rationale": "Multiple threads connect reliable agent work with explicit context capture.",
-                        },
-                        {
-                            "category": "source",
-                            "title": "r/OpenHands",
-                            "rationale": "The current findings suggest growing interest in broader coding-agent workflows.",
-                        },
-                    ]
-                }
-            )
+            def __init__(self, output_text: str) -> None:
+                self.output_text = output_text
 
-        return Response()
+        return Response(self.output_text)
 
 
 class FakeClient:
-    responses = FakeResponses()
+    def __init__(self, output_text: str) -> None:
+        self.responses = FakeResponses(output_text)
 
 
-class FakeRewriteResponses:
-    def create(self, **kwargs):
-        class Response:
-            output_text = json.dumps(
-                {
-                    "topic_rewrites": [
-                        {
-                            "topic_key": "topic_1",
-                            "executive_summary": "Codex threads converge on repeatable local context handling for coding agents.",
-                            "relevance_for_user": "This is relevant because you want a feed that highlights workflows you can reuse quickly.",
-                        },
-                        {
-                            "topic_key": "topic_2",
-                            "executive_summary": "Claude Code discussion emphasizes practical repo editing loops instead of generic hype.",
-                            "relevance_for_user": "This matters because it helps separate immediately usable patterns from noise.",
-                        },
-                    ]
-                }
-            )
-
-        return Response()
+def _suggestions_client() -> FakeClient:
+    return FakeClient(
+        json.dumps(
+            {
+                "suggestions": [
+                    {
+                        "category": "content",
+                        "title": "Prompt-state snapshots",
+                        "rationale": "Multiple threads connect reliable agent work with explicit context capture.",
+                    },
+                    {
+                        "category": "source",
+                        "title": "r/OpenHands",
+                        "rationale": "The current findings suggest growing interest in broader coding-agent workflows.",
+                    },
+                ]
+            }
+        )
+    )
 
 
-class FakeRewriteClient:
-    responses = FakeRewriteResponses()
+def _rewrite_client(*, items: list[dict[str, object]]) -> FakeClient:
+    return FakeClient(json.dumps({"topic_rewrites": items}))
+
+
+def _sample_topics() -> tuple[dict[str, object], ...]:
+    return (
+        {
+            "topic_key": "topic_1",
+            "title": "Codex",
+            "executive_summary": "Codex appears across the day's threads.",
+            "relevance_for_user": "Useful for your AI-assisted development feed.",
+            "source_title": "Codex agent keeps a local context file for every task",
+            "source_subreddit": "Codex",
+            "source_url": "https://reddit.com/r/Codex/comments/post_001",
+            "impact_score": 8.7,
+            "support_count": 3,
+        },
+        {
+            "topic_key": "topic_2",
+            "title": "Claude Code",
+            "executive_summary": "Claude Code threads focus on real repo editing workflows.",
+            "relevance_for_user": "Relevant to AI-enhanced development and testing.",
+            "source_title": "Claude Code repo automation",
+            "source_subreddit": "ClaudeCode",
+            "source_url": "https://reddit.com/r/ClaudeCode/comments/post_002",
+            "impact_score": 7.8,
+            "support_count": 2,
+        },
+    )
+
+
+def _sample_rewrites(*, include_second: bool = True) -> list[dict[str, object]]:
+    items: list[dict[str, object]] = [
+        {
+            "topic_key": "topic_1",
+            "executive_summary": "Codex threads converge on repeatable local context handling for coding agents.",
+            "relevance_for_user": "This is relevant because you want a feed that highlights workflows you can reuse quickly.",
+        }
+    ]
+    if include_second:
+        items.append(
+            {
+                "topic_key": "topic_2",
+                "executive_summary": "Claude Code discussion emphasizes practical repo editing loops instead of generic hype.",
+                "relevance_for_user": "This matters because it helps separate immediately usable patterns from noise.",
+            }
+        )
+    return items
 
 
 def test_generate_suggestions_persists_structured_output(
@@ -88,7 +125,7 @@ def test_generate_suggestions_persists_structured_output(
     )
 
     result = generate_suggestions(
-        FakeClient(),
+        _suggestions_client(),
         model="gpt-5-mini",
         posts=posts,
         insights=insights,
@@ -101,34 +138,47 @@ def test_generate_suggestions_persists_structured_output(
     assert json.loads(result.path.read_text())[0]["title"] == "Prompt-state snapshots"
 
 
+def test_generate_suggestions_rejects_invalid_json(
+    sample_posts_payload: list[dict[str, object]],
+    tmp_path: Path,
+) -> None:
+    posts = tuple(Post.from_raw(item) for item in sample_posts_payload)
+    insights: tuple[Insight, ...] = ()
+
+    with pytest.raises(OpenAIResponseError, match="valid JSON"):
+        generate_suggestions(
+            FakeClient("{not-json"),
+            model="gpt-5-mini",
+            posts=posts,
+            insights=insights,
+            processed_root=tmp_path,
+            run_date="2026-03-12",
+        )
+
+
+def test_generate_suggestions_requires_suggestions_list(
+    sample_posts_payload: list[dict[str, object]],
+    tmp_path: Path,
+) -> None:
+    posts = tuple(Post.from_raw(item) for item in sample_posts_payload)
+    insights: tuple[Insight, ...] = ()
+
+    with pytest.raises(OpenAIResponseError, match="'suggestions' list"):
+        generate_suggestions(
+            FakeClient(json.dumps({"wrong_key": []})),
+            model="gpt-5-mini",
+            posts=posts,
+            insights=insights,
+            processed_root=tmp_path,
+            run_date="2026-03-12",
+        )
+
+
 def test_generate_topic_rewrites_persists_structured_output(tmp_path: Path) -> None:
     result = generate_topic_rewrites(
-        FakeRewriteClient(),
+        _rewrite_client(items=_sample_rewrites()),
         model="gpt-5-mini",
-        topics=(
-            {
-                "topic_key": "topic_1",
-                "title": "Codex",
-                "executive_summary": "Codex appears across the day's threads.",
-                "relevance_for_user": "Useful for your AI-assisted development feed.",
-                "source_title": "Codex agent keeps a local context file for every task",
-                "source_subreddit": "Codex",
-                "source_url": "https://reddit.com/r/Codex/comments/post_001",
-                "impact_score": 8.7,
-                "support_count": 3,
-            },
-            {
-                "topic_key": "topic_2",
-                "title": "Claude Code",
-                "executive_summary": "Claude Code threads focus on real repo editing workflows.",
-                "relevance_for_user": "Relevant to AI-enhanced development and testing.",
-                "source_title": "Claude Code repo automation",
-                "source_subreddit": "ClaudeCode",
-                "source_url": "https://reddit.com/r/ClaudeCode/comments/post_002",
-                "impact_score": 7.8,
-                "support_count": 2,
-            },
-        ),
+        topics=_sample_topics(),
         processed_root=tmp_path,
         run_date="2026-03-12",
     )
@@ -137,3 +187,70 @@ def test_generate_topic_rewrites_persists_structured_output(tmp_path: Path) -> N
     assert result.path.exists()
     persisted = json.loads(result.path.read_text())
     assert persisted[0]["executive_summary"].startswith("Codex threads converge")
+
+
+def test_generate_topic_rewrites_requires_full_topic_coverage(tmp_path: Path) -> None:
+    with pytest.raises(OpenAIResponseError, match="exactly cover the deterministic topic set"):
+        generate_topic_rewrites(
+            _rewrite_client(items=_sample_rewrites(include_second=False)),
+            model="gpt-5-mini",
+            topics=_sample_topics(),
+            processed_root=tmp_path,
+            run_date="2026-03-12",
+        )
+
+
+def test_generate_topic_rewrites_rejects_unknown_topic_keys(tmp_path: Path) -> None:
+    with pytest.raises(OpenAIResponseError, match="unexpected: topic_3"):
+        generate_topic_rewrites(
+            _rewrite_client(
+                items=[
+                    *_sample_rewrites(include_second=False),
+                    {
+                        "topic_key": "topic_3",
+                        "executive_summary": "Unexpected extra topic.",
+                        "relevance_for_user": "This should be rejected.",
+                    },
+                ]
+            ),
+            model="gpt-5-mini",
+            topics=_sample_topics(),
+            processed_root=tmp_path,
+            run_date="2026-03-12",
+        )
+
+
+def test_generate_topic_rewrites_rejects_duplicate_topic_keys(tmp_path: Path) -> None:
+    with pytest.raises(OpenAIResponseError, match="duplicate topic_key"):
+        generate_topic_rewrites(
+            _rewrite_client(
+                items=[
+                    *_sample_rewrites(include_second=False),
+                    {
+                        "topic_key": "topic_1",
+                        "executive_summary": "Duplicate rewrite.",
+                        "relevance_for_user": "This should be rejected.",
+                    },
+                    {
+                        "topic_key": "topic_2",
+                        "executive_summary": "Claude Code discussion emphasizes practical repo editing loops instead of generic hype.",
+                        "relevance_for_user": "This matters because it helps separate immediately usable patterns from noise.",
+                    },
+                ]
+            ),
+            model="gpt-5-mini",
+            topics=_sample_topics(),
+            processed_root=tmp_path,
+            run_date="2026-03-12",
+        )
+
+
+def test_generate_topic_rewrites_requires_topic_rewrites_list(tmp_path: Path) -> None:
+    with pytest.raises(OpenAIResponseError, match="'topic_rewrites' list"):
+        generate_topic_rewrites(
+            FakeClient(json.dumps({"rewrites": []})),
+            model="gpt-5-mini",
+            topics=_sample_topics(),
+            processed_root=tmp_path,
+            run_date="2026-03-12",
+        )


### PR DESCRIPTION
## Summary
- validate OpenAI JSON payloads before converting them into suggestions or topic rewrites
- require topic rewrite outputs to exactly cover the deterministic topic set
- add malformed, missing-field, duplicate, and partial-coverage tests

## Testing
- PYTHONPATH=src /Users/wojciechwieczorek/Sii/reddit-ai-agents-digest/.venv/bin/pytest tests/test_openai_suggestions.py
- PYTHONPATH=src /Users/wojciechwieczorek/Sii/reddit-ai-agents-digest/.venv/bin/pytest

Closes #62