### PR TITLE
Share Reddit transport and artifact writing

### DIFF
--- a/src/reddit_digest/collectors/reddit_comments.py
+++ b/src/reddit_digest/collectors/reddit_comments.py
@@ -6,13 +6,14 @@ from dataclasses import dataclass
 from datetime import UTC
 from datetime import datetime
 from pathlib import Path
-import json
 from typing import Any
 from typing import Protocol
 
 from praw.models import Submission
 import requests
 
+from reddit_digest.collectors.shared import PublicRedditTransport
+from reddit_digest.collectors.shared import write_json_artifact
 from reddit_digest.config import RuntimeConfig
 from reddit_digest.models.base import ModelError
 from reddit_digest.models.comment import Comment
@@ -66,20 +67,17 @@ class PrawRedditCommentSource:
 class PublicRedditCommentSource:
     """Live Reddit comment source backed by public JSON endpoints."""
 
-    def __init__(self, runtime: RuntimeConfig, *, session: requests.Session | None = None) -> None:
-        self._session = session or requests.Session()
-        self._session.headers.update(
-            {
-                "User-Agent": runtime.reddit_user_agent or "reddit-ai-agents-digest/0.1.0",
-                "Accept": "application/json",
-            }
-        )
+    def __init__(
+        self,
+        runtime: RuntimeConfig,
+        *,
+        session: requests.Session | None = None,
+        transport: PublicRedditTransport | None = None,
+    ) -> None:
+        self._transport = transport or PublicRedditTransport(runtime, session=session)
 
     def fetch_comments(self, post: Post, limit: int) -> list[dict[str, Any]]:
-        url = f"https://www.reddit.com/comments/{post.id}.json"
-        response = self._session.get(url, params={"limit": limit, "raw_json": 1}, timeout=20)
-        response.raise_for_status()
-        payload = response.json()
+        payload = self._transport.get_json(f"/comments/{post.id}.json", params={"limit": limit, "raw_json": 1})
         if not isinstance(payload, list) or len(payload) < 2:
             return []
         return self._flatten_comment_listing(payload[1], post=post)[:limit]
@@ -162,8 +160,8 @@ class CommentCollector:
                 self._normalize_comments(raw_comments, max_comments_per_post=max_comments_per_post)
             )
 
-        raw_path = self._write_json(self._raw_root / "comments" / f"{run_date}.json", raw_payload)
-        processed_path = self._write_json(
+        raw_path = write_json_artifact(self._raw_root / "comments" / f"{run_date}.json", raw_payload)
+        processed_path = write_json_artifact(
             self._processed_root / "comments" / f"{run_date}.json",
             [comment.to_dict() for comment in normalized_comments],
         )
@@ -187,8 +185,3 @@ class CommentCollector:
             if len(normalized) >= max_comments_per_post:
                 break
         return normalized
-
-    def _write_json(self, path: Path, payload: Any) -> Path:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(payload, indent=2, sort_keys=True))
-        return path

--- a/src/reddit_digest/collectors/reddit_posts.py
+++ b/src/reddit_digest/collectors/reddit_posts.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from datetime import UTC
 from datetime import datetime
 from pathlib import Path
-import json
 from typing import Any
 from typing import Protocol
 
@@ -16,6 +15,8 @@ import requests
 
 from reddit_digest.config import RuntimeConfig
 from reddit_digest.config import SubredditConfig
+from reddit_digest.collectors.shared import PublicRedditTransport
+from reddit_digest.collectors.shared import write_json_artifact
 from reddit_digest.models.base import ModelError
 from reddit_digest.models.post import Post
 
@@ -76,23 +77,20 @@ class PrawRedditPostSource:
 class PublicRedditPostSource:
     """Live Reddit source backed by public JSON endpoints."""
 
-    def __init__(self, runtime: RuntimeConfig, *, session: requests.Session | None = None) -> None:
-        self._session = session or requests.Session()
-        self._session.headers.update(
-            {
-                "User-Agent": runtime.reddit_user_agent or "reddit-ai-agents-digest/0.1.0",
-                "Accept": "application/json",
-            }
-        )
+    def __init__(
+        self,
+        runtime: RuntimeConfig,
+        *,
+        session: requests.Session | None = None,
+        transport: PublicRedditTransport | None = None,
+    ) -> None:
+        self._transport = transport or PublicRedditTransport(runtime, session=session)
 
     def fetch_posts(self, subreddit: str, sort_mode: str, limit: int) -> list[dict[str, Any]]:
-        url = f"https://www.reddit.com/r/{subreddit}/{sort_mode}.json"
         params: dict[str, Any] = {"limit": limit, "raw_json": 1}
         if sort_mode == "top":
             params["t"] = "day"
-        response = self._session.get(url, params=params, timeout=20)
-        response.raise_for_status()
-        payload = response.json()
+        payload = self._transport.get_json(f"/r/{subreddit}/{sort_mode}.json", params=params)
         return self._parse_listing(payload)
 
     def _parse_listing(self, payload: Any) -> list[dict[str, Any]]:
@@ -144,8 +142,8 @@ class PostCollector:
         minimum_created_utc = int(current_time.timestamp()) - (config.fetch.lookback_hours * 3600)
         raw_payload = self._fetch_and_filter(config, minimum_created_utc=minimum_created_utc)
         posts = self._normalize_posts(raw_payload)
-        raw_path = self._write_json(self._raw_root / "posts" / f"{run_date}.json", raw_payload)
-        processed_path = self._write_json(
+        raw_path = write_json_artifact(self._raw_root / "posts" / f"{run_date}.json", raw_payload)
+        processed_path = write_json_artifact(
             self._processed_root / "posts" / f"{run_date}.json",
             [post.to_dict() for post in posts],
         )
@@ -198,8 +196,3 @@ class PostCollector:
             for item in subreddit_payload["selected"]:
                 posts.append(Post.from_raw(item))
         return posts
-
-    def _write_json(self, path: Path, payload: Any) -> Path:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(payload, indent=2, sort_keys=True))
-        return path

--- a/src/reddit_digest/collectors/shared.py
+++ b/src/reddit_digest/collectors/shared.py
@@ -1,0 +1,42 @@
+"""Shared transport and artifact helpers for Reddit collection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+from typing import Any
+
+import requests
+
+from reddit_digest.config import RuntimeConfig
+
+
+def write_json_artifact(path: Path, payload: Any) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    return path
+
+
+class PublicRedditTransport:
+    """Shared HTTP policy for public Reddit JSON collection."""
+
+    def __init__(
+        self,
+        runtime: RuntimeConfig,
+        *,
+        session: requests.Session | None = None,
+        base_url: str = "https://www.reddit.com",
+    ) -> None:
+        self._session = session or requests.Session()
+        self._base_url = base_url.rstrip("/")
+        self._session.headers.update(
+            {
+                "User-Agent": runtime.reddit_user_agent or "reddit-ai-agents-digest/0.1.0",
+                "Accept": "application/json",
+            }
+        )
+
+    def get_json(self, path: str, *, params: dict[str, Any], timeout: int = 20) -> Any:
+        response = self._session.get(f"{self._base_url}/{path.lstrip('/')}", params=params, timeout=timeout)
+        response.raise_for_status()
+        return response.json()

--- a/tests/test_reddit_shared.py
+++ b/tests/test_reddit_shared.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+from reddit_digest.collectors.shared import PublicRedditTransport
+from reddit_digest.collectors.shared import write_json_artifact
+from reddit_digest.config import RuntimeConfig
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self, payload):
+        self.payload = payload
+        self.headers: dict[str, str] = {}
+        self.calls: list[tuple[str, dict[str, object], int]] = []
+
+    def get(self, url, params=None, timeout=20):
+        self.calls.append((url, params or {}, timeout))
+        return FakeResponse(self.payload)
+
+
+def runtime() -> RuntimeConfig:
+    return RuntimeConfig(
+        reddit_client_id=None,
+        reddit_client_secret=None,
+        reddit_user_agent="digest-test-agent",
+        openai_api_key=None,
+        openai_model="gpt-5-mini",
+        gcp_workload_identity_provider=None,
+        gcp_service_account_email=None,
+        google_service_account_json=None,
+        google_sheets_spreadsheet_id=None,
+    )
+
+
+def test_public_reddit_transport_applies_shared_request_policy() -> None:
+    session = FakeSession({"ok": True})
+    transport = PublicRedditTransport(runtime(), session=session)
+
+    payload = transport.get_json("/r/Codex/new.json", params={"limit": 5, "raw_json": 1})
+
+    assert payload == {"ok": True}
+    assert session.headers["User-Agent"] == "digest-test-agent"
+    assert session.headers["Accept"] == "application/json"
+    assert session.calls == [("https://www.reddit.com/r/Codex/new.json", {"limit": 5, "raw_json": 1}, 20)]
+
+
+def test_write_json_artifact_persists_sorted_payload(tmp_path: Path) -> None:
+    path = write_json_artifact(tmp_path / "processed" / "posts" / "2026-03-12.json", {"b": 2, "a": 1})
+
+    assert path.exists()
+    assert json.loads(path.read_text()) == {"a": 1, "b": 2}


### PR DESCRIPTION
## Summary
- extract a shared public Reddit transport with the common request headers and JSON fetch policy
- centralize deterministic JSON artifact persistence for collectors
- rewire post and comment collection to use the shared infrastructure without changing outputs

## Testing
- PYTHONPATH=src /Users/wojciechwieczorek/Sii/reddit-ai-agents-digest/.venv/bin/pytest tests/test_reddit_posts.py tests/test_reddit_comments.py tests/test_public_reddit_json.py tests/test_reddit_shared.py
- PYTHONPATH=src /Users/wojciechwieczorek/Sii/reddit-ai-agents-digest/.venv/bin/pytest

Closes #63