### PR TITLE
Move extraction rules into a registry

### DIFF
--- a/src/reddit_digest/extractors/approaches.py
+++ b/src/reddit_digest/extractors/approaches.py
@@ -2,26 +2,8 @@
 
 from __future__ import annotations
 
-import re
-
 from reddit_digest.extractors.common import InsightPattern
+from reddit_digest.extractors.registry import patterns_for_ruleset
 
 
-APPROACH_PATTERNS: tuple[InsightPattern, ...] = (
-    InsightPattern(
-        title="Test-first refactors",
-        category="approaches",
-        summary="Authors are using tests or fixtures before asking agents to change production code.",
-        why_it_matters="This makes AI-assisted changes safer and easier to verify.",
-        tags=("ai-dev-workflow", "ai-testing", "reliability"),
-        regex=re.compile(r"test-first|fixtures before|before asking the model"),
-    ),
-    InsightPattern(
-        title="Context snapshots",
-        category="approaches",
-        summary="Teams are capturing local context snapshots before each AI-assisted change.",
-        why_it_matters="Stable context helps with recovery and reduces drift across iterations.",
-        tags=("ai-dev-workflow", "coding-agents", "prompting"),
-        regex=re.compile(r"context file|snapshot the repo state|context snapshots?"),
-    ),
-)
+APPROACH_PATTERNS: tuple[InsightPattern, ...] = patterns_for_ruleset("approaches")

--- a/src/reddit_digest/extractors/guides.py
+++ b/src/reddit_digest/extractors/guides.py
@@ -2,26 +2,8 @@
 
 from __future__ import annotations
 
-import re
-
 from reddit_digest.extractors.common import InsightPattern
+from reddit_digest.extractors.registry import patterns_for_ruleset
 
 
-GUIDE_PATTERNS: tuple[InsightPattern, ...] = (
-    InsightPattern(
-        title="Local context file pattern",
-        category="guides",
-        summary="A reusable context-file pattern is being shared as a repeatable resource.",
-        why_it_matters="It gives other practitioners a concrete way to structure agent context.",
-        tags=("prompting", "coding-agents", "tooling"),
-        regex=re.compile(r"context file"),
-    ),
-    InsightPattern(
-        title="Prompt recovery checklist",
-        category="guides",
-        summary="People are sharing explicit recovery steps for resuming interrupted agent work.",
-        why_it_matters="Recovery patterns make longer-running AI workflows more reliable.",
-        tags=("reliability", "prompting", "ai-dev-workflow"),
-        regex=re.compile(r"prompt recovery|recovery"),
-    ),
-)
+GUIDE_PATTERNS: tuple[InsightPattern, ...] = patterns_for_ruleset("guides")

--- a/src/reddit_digest/extractors/registry.py
+++ b/src/reddit_digest/extractors/registry.py
@@ -1,0 +1,130 @@
+"""Declarative extraction rule registry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+from reddit_digest.extractors.common import InsightPattern
+
+
+@dataclass(frozen=True)
+class RuleSet:
+    name: str
+    patterns: tuple[InsightPattern, ...]
+
+
+def _build_patterns(definitions: tuple[dict[str, object], ...]) -> tuple[InsightPattern, ...]:
+    patterns: list[InsightPattern] = []
+    for definition in definitions:
+        patterns.append(
+            InsightPattern(
+                title=str(definition["title"]),
+                category=str(definition["category"]),
+                summary=str(definition["summary"]),
+                why_it_matters=str(definition["why_it_matters"]),
+                tags=tuple(str(tag) for tag in definition["tags"]),
+                regex=re.compile(str(definition["regex"])),
+            )
+        )
+    return tuple(patterns)
+
+
+_RULE_DEFINITIONS: tuple[tuple[str, tuple[dict[str, object], ...]], ...] = (
+    (
+        "tools",
+        (
+            {
+                "title": "Codex",
+                "category": "tools",
+                "summary": "Codex is being used as an agentic coding tool in real workflows.",
+                "why_it_matters": "It appears in hands-on discussions about practical agent-assisted coding.",
+                "tags": ("ai-agents", "tooling", "coding-agents"),
+                "regex": r"\bcodex\b",
+            },
+            {
+                "title": "Claude Code",
+                "category": "tools",
+                "summary": "Claude Code is being used to support structured software workflows.",
+                "why_it_matters": "It is discussed as an applied coding tool rather than generic AI chat.",
+                "tags": ("ai-agents", "tooling", "ai-dev-workflow"),
+                "regex": r"\bclaude code\b",
+            },
+        ),
+    ),
+    (
+        "approaches",
+        (
+            {
+                "title": "Test-first refactors",
+                "category": "approaches",
+                "summary": "Authors are using tests or fixtures before asking agents to change production code.",
+                "why_it_matters": "This makes AI-assisted changes safer and easier to verify.",
+                "tags": ("ai-dev-workflow", "ai-testing", "reliability"),
+                "regex": r"test-first|fixtures before|before asking the model",
+            },
+            {
+                "title": "Context snapshots",
+                "category": "approaches",
+                "summary": "Teams are capturing local context snapshots before each AI-assisted change.",
+                "why_it_matters": "Stable context helps with recovery and reduces drift across iterations.",
+                "tags": ("ai-dev-workflow", "coding-agents", "prompting"),
+                "regex": r"context file|snapshot the repo state|context snapshots?",
+            },
+        ),
+    ),
+    (
+        "guides",
+        (
+            {
+                "title": "Local context file pattern",
+                "category": "guides",
+                "summary": "A reusable context-file pattern is being shared as a repeatable resource.",
+                "why_it_matters": "It gives other practitioners a concrete way to structure agent context.",
+                "tags": ("prompting", "coding-agents", "tooling"),
+                "regex": r"context file",
+            },
+            {
+                "title": "Prompt recovery checklist",
+                "category": "guides",
+                "summary": "People are sharing explicit recovery steps for resuming interrupted agent work.",
+                "why_it_matters": "Recovery patterns make longer-running AI workflows more reliable.",
+                "tags": ("reliability", "prompting", "ai-dev-workflow"),
+                "regex": r"prompt recovery|recovery",
+            },
+        ),
+    ),
+    (
+        "testing",
+        (
+            {
+                "title": "Snapshot markdown tests",
+                "category": "testing",
+                "summary": "Snapshot-style output tests are being used to catch formatting regressions.",
+                "why_it_matters": "Deterministic report generation becomes testable and safer to change.",
+                "tags": ("ai-testing", "reliability", "tooling"),
+                "regex": r"snapshot.*tests?|markdown output tests",
+            },
+            {
+                "title": "Deterministic prompting",
+                "category": "testing",
+                "summary": "Prompt stability is being treated as a software quality concern.",
+                "why_it_matters": "Repeatable prompting improves trust in AI-assisted development workflows.",
+                "tags": ("prompting", "reliability", "ai-testing"),
+                "regex": r"deterministic",
+            },
+        ),
+    ),
+)
+
+RULESETS: tuple[RuleSet, ...] = tuple(
+    RuleSet(name=name, patterns=_build_patterns(definitions))
+    for name, definitions in _RULE_DEFINITIONS
+)
+
+
+def patterns_for_ruleset(name: str) -> tuple[InsightPattern, ...]:
+    for ruleset in RULESETS:
+        if ruleset.name == name:
+            return ruleset.patterns
+    raise KeyError(name)

--- a/src/reddit_digest/extractors/service.py
+++ b/src/reddit_digest/extractors/service.py
@@ -6,13 +6,11 @@ from dataclasses import dataclass
 from pathlib import Path
 import json
 
-from reddit_digest.extractors.approaches import APPROACH_PATTERNS
 from reddit_digest.extractors.common import comment_source
 from reddit_digest.extractors.common import match_patterns
 from reddit_digest.extractors.common import post_source
-from reddit_digest.extractors.guides import GUIDE_PATTERNS
-from reddit_digest.extractors.testing_insights import TESTING_PATTERNS
-from reddit_digest.extractors.tools import TOOL_PATTERNS
+from reddit_digest.extractors.common import TextSource
+from reddit_digest.extractors.registry import RULESETS
 from reddit_digest.models.comment import Comment
 from reddit_digest.models.insight import Insight
 from reddit_digest.models.post import Post
@@ -41,18 +39,10 @@ def extract_insights(
 def _extract(posts: tuple[Post, ...], comments: tuple[Comment, ...]) -> list[Insight]:
     extracted: list[Insight] = []
     for post in posts:
-        source = post_source(post)
-        extracted.extend(match_patterns(source, TOOL_PATTERNS))
-        extracted.extend(match_patterns(source, APPROACH_PATTERNS))
-        extracted.extend(match_patterns(source, GUIDE_PATTERNS))
-        extracted.extend(match_patterns(source, TESTING_PATTERNS))
+        extracted.extend(_match_rulesets(post_source(post)))
 
     for comment in comments:
-        source = comment_source(comment)
-        extracted.extend(match_patterns(source, TOOL_PATTERNS))
-        extracted.extend(match_patterns(source, APPROACH_PATTERNS))
-        extracted.extend(match_patterns(source, GUIDE_PATTERNS))
-        extracted.extend(match_patterns(source, TESTING_PATTERNS))
+        extracted.extend(_match_rulesets(comment_source(comment)))
 
     deduped: dict[tuple[str, str, str], Insight] = {}
     for insight in extracted:
@@ -63,3 +53,10 @@ def _extract(posts: tuple[Post, ...], comments: tuple[Comment, ...]) -> list[Ins
         deduped.values(),
         key=lambda insight: (insight.category, insight.title, insight.source_id),
     )
+
+
+def _match_rulesets(source: TextSource) -> list[Insight]:
+    extracted: list[Insight] = []
+    for ruleset in RULESETS:
+        extracted.extend(match_patterns(source, ruleset.patterns))
+    return extracted

--- a/src/reddit_digest/extractors/testing_insights.py
+++ b/src/reddit_digest/extractors/testing_insights.py
@@ -2,26 +2,8 @@
 
 from __future__ import annotations
 
-import re
-
 from reddit_digest.extractors.common import InsightPattern
+from reddit_digest.extractors.registry import patterns_for_ruleset
 
 
-TESTING_PATTERNS: tuple[InsightPattern, ...] = (
-    InsightPattern(
-        title="Snapshot markdown tests",
-        category="testing",
-        summary="Snapshot-style output tests are being used to catch formatting regressions.",
-        why_it_matters="Deterministic report generation becomes testable and safer to change.",
-        tags=("ai-testing", "reliability", "tooling"),
-        regex=re.compile(r"snapshot.*tests?|markdown output tests"),
-    ),
-    InsightPattern(
-        title="Deterministic prompting",
-        category="testing",
-        summary="Prompt stability is being treated as a software quality concern.",
-        why_it_matters="Repeatable prompting improves trust in AI-assisted development workflows.",
-        tags=("prompting", "reliability", "ai-testing"),
-        regex=re.compile(r"deterministic"),
-    ),
-)
+TESTING_PATTERNS: tuple[InsightPattern, ...] = patterns_for_ruleset("testing")

--- a/src/reddit_digest/extractors/tools.py
+++ b/src/reddit_digest/extractors/tools.py
@@ -2,26 +2,8 @@
 
 from __future__ import annotations
 
-import re
-
 from reddit_digest.extractors.common import InsightPattern
+from reddit_digest.extractors.registry import patterns_for_ruleset
 
 
-TOOL_PATTERNS: tuple[InsightPattern, ...] = (
-    InsightPattern(
-        title="Codex",
-        category="tools",
-        summary="Codex is being used as an agentic coding tool in real workflows.",
-        why_it_matters="It appears in hands-on discussions about practical agent-assisted coding.",
-        tags=("ai-agents", "tooling", "coding-agents"),
-        regex=re.compile(r"\bcodex\b"),
-    ),
-    InsightPattern(
-        title="Claude Code",
-        category="tools",
-        summary="Claude Code is being used to support structured software workflows.",
-        why_it_matters="It is discussed as an applied coding tool rather than generic AI chat.",
-        tags=("ai-agents", "tooling", "ai-dev-workflow"),
-        regex=re.compile(r"\bclaude code\b"),
-    ),
-)
+TOOL_PATTERNS: tuple[InsightPattern, ...] = patterns_for_ruleset("tools")

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 import json
 
+from reddit_digest.extractors.registry import RULESETS
+from reddit_digest.extractors.registry import patterns_for_ruleset
 from reddit_digest.extractors.service import extract_insights
 from reddit_digest.models.comment import Comment
 from reddit_digest.models.post import Post
@@ -52,3 +54,9 @@ def test_extract_insights_handles_no_matches(sample_posts_payload: list[dict[str
 
     assert result.insights == ()
     assert json.loads(result.path.read_text()) == []
+
+
+def test_extractor_registry_defines_rulesets_without_service_wiring() -> None:
+    assert [ruleset.name for ruleset in RULESETS] == ["tools", "approaches", "guides", "testing"]
+    assert any(pattern.title == "Codex" for pattern in patterns_for_ruleset("tools"))
+    assert any(pattern.title == "Deterministic prompting" for pattern in patterns_for_ruleset("testing"))


### PR DESCRIPTION
## Summary
- move the simple extractor rule definitions into a declarative registry module
- make extraction orchestration iterate the registry instead of naming each category module explicitly
- keep compatibility exports for the existing pattern modules and add registry coverage tests

## Testing
- PYTHONPATH=src /Users/wojciechwieczorek/Sii/reddit-ai-agents-digest/.venv/bin/pytest tests/test_extractors.py tests/test_imports.py
- PYTHONPATH=src /Users/wojciechwieczorek/Sii/reddit-ai-agents-digest/.venv/bin/pytest

Closes #64