### PR TITLE
Share a structured digest artifact across outputs

### DIFF
--- a/src/reddit_digest/outputs/digest.py
+++ b/src/reddit_digest/outputs/digest.py
@@ -1,0 +1,183 @@
+"""Structured digest artifact shared by downstream outputs."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections import defaultdict
+from dataclasses import dataclass
+
+from reddit_digest.config import ScoringConfig
+from reddit_digest.models.insight import Insight
+from reddit_digest.ranking.impact import score_insight
+from reddit_digest.ranking.threads import ThreadSelection
+
+
+@dataclass(frozen=True)
+class RankedTopic:
+    topic_key: str
+    title: str
+    executive_summary: str
+    relevance_for_user: str
+    source_title: str
+    source_url: str
+    source_subreddit: str
+    impact_score: float
+    support_count: int
+
+
+@dataclass(frozen=True)
+class DigestThread:
+    title: str
+    url: str
+    subreddit: str
+    impact_score: float
+
+
+@dataclass(frozen=True)
+class EmergingTheme:
+    label: str
+    evidence: str
+
+
+@dataclass(frozen=True)
+class DigestArtifact:
+    run_date: str
+    total_posts: int
+    total_insights: int
+    represented_subreddits: tuple[str, ...]
+    top_topic_title: str | None
+    top_tool: str
+    top_approach: str
+    top_guide: str
+    top_testing_insight: str
+    topics: tuple[RankedTopic, ...]
+    notable_threads: tuple[DigestThread, ...]
+    emerging_themes: tuple[EmergingTheme, ...]
+    watch_next: tuple[str, ...]
+
+    @property
+    def top_thread(self) -> DigestThread | None:
+        return self.notable_threads[0] if self.notable_threads else None
+
+
+def select_digest_topics(
+    *,
+    insights: tuple[Insight, ...],
+    scoring: ScoringConfig,
+    thread_selection: ThreadSelection,
+    limit: int = 6,
+) -> tuple[RankedTopic, ...]:
+    scored_insights = sorted(
+        [(insight, score_insight(insight, scoring)) for insight in insights],
+        key=lambda item: (item[0].category, -item[1].total, item[0].title, item[0].source_id),
+    )
+    grouped: dict[tuple[str, str], list[tuple[Insight, object]]] = defaultdict(list)
+    for insight, breakdown in scored_insights:
+        grouped[(insight.category, insight.title.casefold())].append((insight, breakdown))
+
+    post_lookup = {ranked.post.id: ranked.post for ranked in thread_selection.ranked_posts}
+    topics: list[RankedTopic] = []
+    for entries in grouped.values():
+        best_insight, best_breakdown = sorted(
+            entries,
+            key=lambda item: (-item[1].total, item[0].title, item[0].source_id),
+        )[0]
+        source_post = post_lookup.get(best_insight.source_post_id)
+        source_title = source_post.title if source_post is not None else best_insight.title
+        source_url = source_post.url if source_post is not None else best_insight.source_permalink
+        source_subreddit = source_post.subreddit if source_post is not None else best_insight.subreddit
+        support_count = len({insight.source_post_id for insight, _ in entries})
+        topics.append(
+            RankedTopic(
+                topic_key="",
+                title=best_insight.title,
+                executive_summary=best_insight.summary,
+                relevance_for_user=best_insight.why_it_matters or best_insight.summary,
+                source_title=source_title,
+                source_url=source_url,
+                source_subreddit=source_subreddit,
+                impact_score=best_breakdown.total,
+                support_count=support_count,
+            )
+        )
+
+    ordered_topics = sorted(topics, key=lambda item: (-item.impact_score, item.title, item.source_url))[:limit]
+    return tuple(
+        RankedTopic(
+            topic_key=f"topic_{index}",
+            title=topic.title,
+            executive_summary=topic.executive_summary,
+            relevance_for_user=topic.relevance_for_user,
+            source_title=topic.source_title,
+            source_url=topic.source_url,
+            source_subreddit=topic.source_subreddit,
+            impact_score=topic.impact_score,
+            support_count=topic.support_count,
+        )
+        for index, topic in enumerate(ordered_topics, start=1)
+    )
+
+
+def build_digest_artifact(
+    *,
+    run_date: str,
+    insights: tuple[Insight, ...],
+    scoring: ScoringConfig,
+    thread_selection: ThreadSelection,
+    watch_next: tuple[str, ...] = (),
+    topics: tuple[RankedTopic, ...] | None = None,
+) -> DigestArtifact:
+    scored_insights = sorted(
+        [(insight, score_insight(insight, scoring)) for insight in insights],
+        key=lambda item: (item[0].category, -item[1].total, item[0].title, item[0].source_id),
+    )
+    selected_topics = topics or select_digest_topics(
+        insights=insights,
+        scoring=scoring,
+        thread_selection=thread_selection,
+    )
+    represented = tuple(dict.fromkeys(item.post.subreddit for item in thread_selection.ranked_posts))
+
+    top_by_category = {category: "" for category in ("tools", "approaches", "guides", "testing")}
+    for insight, _breakdown in scored_insights:
+        if not top_by_category.get(insight.category):
+            top_by_category[insight.category] = insight.title
+
+    tags = Counter(tag for insight, _ in scored_insights for tag in insight.tags)
+    emerging_themes = tuple(
+        EmergingTheme(
+            label=tag.replace("-", " ").title(),
+            evidence=", ".join(insight.title for insight, _ in scored_insights if tag in insight.tags),
+        )
+        for tag, _count in tags.most_common(3)
+    )
+
+    resolved_watch_next = watch_next or tuple(
+        insight.title for insight, _ in scored_insights if insight.novelty == "new"
+    )[:3]
+
+    notable_threads = tuple(
+        DigestThread(
+            title=ranked.post.title,
+            url=ranked.post.url,
+            subreddit=ranked.post.subreddit,
+            impact_score=ranked.breakdown.total,
+        )
+        for ranked in thread_selection.notable_threads
+    )
+
+    return DigestArtifact(
+        run_date=run_date,
+        total_posts=len(thread_selection.ranked_posts),
+        total_insights=len(insights),
+        represented_subreddits=represented,
+        top_topic_title=selected_topics[0].title if selected_topics else None,
+        top_tool=top_by_category["tools"],
+        top_approach=top_by_category["approaches"],
+        top_guide=top_by_category["guides"],
+        top_testing_insight=top_by_category["testing"],
+        topics=selected_topics,
+        notable_threads=notable_threads,
+        emerging_themes=emerging_themes,
+        watch_next=resolved_watch_next,
+    )

--- a/src/reddit_digest/outputs/google_sheets.py
+++ b/src/reddit_digest/outputs/google_sheets.py
@@ -20,6 +20,7 @@ from reddit_digest.config import RuntimeConfig
 from reddit_digest.config import ScoringConfig
 from reddit_digest.models.insight import Insight
 from reddit_digest.models.post import Post
+from reddit_digest.outputs.digest import DigestArtifact
 from reddit_digest.ranking.impact import score_insight
 from reddit_digest.ranking.impact import score_post
 
@@ -77,7 +78,7 @@ class GoogleSheetsExporter:
         run_date: str,
         posts: tuple[Post, ...],
         insights: tuple[Insight, ...],
-        markdown_content: str,
+        digest: DigestArtifact,
         scoring: ScoringConfig,
         lookback_hours: int,
         run_at: datetime | None = None,
@@ -85,7 +86,7 @@ class GoogleSheetsExporter:
         effective_run_at = run_at or datetime.now(tz=UTC)
         raw_post_rows = _build_raw_post_rows(posts, scoring, run_date=run_date, lookback_hours=lookback_hours, run_at=effective_run_at)
         insight_rows = _build_insight_rows(insights, scoring, run_date=run_date)
-        digest_row = _build_daily_digest_row(run_date=run_date, posts=posts, insights=insights, markdown_content=markdown_content)
+        digest_row = _build_daily_digest_row(digest)
 
         self._upsert_rows(RAW_POSTS_TAB, RAW_POST_HEADERS, run_date, raw_post_rows)
         self._upsert_rows(INSIGHTS_TAB, INSIGHT_HEADERS, run_date, insight_rows)
@@ -225,43 +226,18 @@ def _build_insight_rows(insights: tuple[Insight, ...], scoring: ScoringConfig, *
 
 
 def _build_daily_digest_row(
-    *,
-    run_date: str,
-    posts: tuple[Post, ...],
-    insights: tuple[Insight, ...],
-    markdown_content: str,
+    digest: DigestArtifact,
 ) -> dict[str, Any]:
-    top_thread = posts[0] if posts else None
-    top_by_category = {category: "" for category in ("tools", "approaches", "guides", "testing")}
-    for insight in insights:
-        if not top_by_category.get(insight.category):
-            top_by_category[insight.category] = insight.title
-
-    watch_next_lines = _extract_watch_next_lines(markdown_content)
+    top_thread = digest.top_thread
     return {
-        "run_date": run_date,
-        "total_posts": len(posts),
-        "total_insights": len(insights),
+        "run_date": digest.run_date,
+        "total_posts": digest.total_posts,
+        "total_insights": digest.total_insights,
         "top_thread_title": "" if top_thread is None else top_thread.title,
         "top_thread_url": "" if top_thread is None else top_thread.url,
-        "top_tool": top_by_category["tools"],
-        "top_approach": top_by_category["approaches"],
-        "top_guide": top_by_category["guides"],
-        "top_testing_insight": top_by_category["testing"],
-        "watch_next": " | ".join(watch_next_lines[:3]),
+        "top_tool": digest.top_tool,
+        "top_approach": digest.top_approach,
+        "top_guide": digest.top_guide,
+        "top_testing_insight": digest.top_testing_insight,
+        "watch_next": " | ".join(digest.watch_next[:3]),
     }
-
-
-def _extract_watch_next_lines(markdown_content: str) -> list[str]:
-    lines = markdown_content.splitlines()
-    in_watch_next = False
-    collected: list[str] = []
-    for line in lines:
-        if line == "## Watch Next":
-            in_watch_next = True
-            continue
-        if in_watch_next and line.startswith("## "):
-            break
-        if in_watch_next and line.startswith("- "):
-            collected.append(line[2:])
-    return collected

--- a/src/reddit_digest/outputs/markdown.py
+++ b/src/reddit_digest/outputs/markdown.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from collections import Counter
-from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 
 from reddit_digest.config import ScoringConfig
+from reddit_digest.outputs.digest import build_digest_artifact
+from reddit_digest.outputs.digest import DigestArtifact
+from reddit_digest.outputs.digest import RankedTopic
+from reddit_digest.outputs.digest import select_digest_topics
 from reddit_digest.models.insight import Insight
-from reddit_digest.ranking.impact import score_insight
 from reddit_digest.ranking.threads import ThreadSelection
 
 
@@ -19,19 +20,6 @@ class MarkdownDigestResult:
     daily_path: Path
     latest_path: Path
     content: str
-
-
-@dataclass(frozen=True)
-class RankedTopic:
-    topic_key: str
-    title: str
-    executive_summary: str
-    relevance_for_user: str
-    source_title: str
-    source_url: str
-    source_subreddit: str
-    impact_score: float
-    support_count: int
 
 
 def render_markdown_digest(
@@ -44,26 +32,26 @@ def render_markdown_digest(
     watch_next: tuple[str, ...] = (),
     warnings: tuple[str, ...] = (),
     topics: tuple[RankedTopic, ...] | None = None,
+    digest: DigestArtifact | None = None,
     topic_rewrites: Mapping[str, tuple[str, str]] | None = None,
     variant_suffix: str = "",
 ) -> MarkdownDigestResult:
-    scored_insights = sorted(
-        [(insight, score_insight(insight, scoring)) for insight in insights],
-        key=lambda item: (item[0].category, -item[1].total, item[0].title, item[0].source_id),
-    )
-    selected_topics = topics or select_digest_topics(
+    artifact = digest or build_digest_artifact(
+        run_date=run_date,
         insights=insights,
         scoring=scoring,
         thread_selection=thread_selection,
+        watch_next=watch_next,
+        topics=topics,
     )
 
     lines = [f"# Daily Reddit Digest — {run_date}", ""]
     if warnings:
         lines.extend(_render_warnings(warnings))
-    lines.extend(_render_executive_summary(thread_selection, selected_topics))
-    lines.extend(_render_picked_topics(selected_topics, topic_rewrites=topic_rewrites))
-    lines.extend(_render_emerging_themes(scored_insights))
-    watch_next_lines = _render_watch_next(watch_next=watch_next, scored_insights=scored_insights)
+    lines.extend(_render_executive_summary(artifact))
+    lines.extend(_render_picked_topics(artifact.topics, topic_rewrites=topic_rewrites))
+    lines.extend(_render_emerging_themes(artifact))
+    watch_next_lines = _render_watch_next(artifact)
     if watch_next_lines:
         lines.extend(watch_next_lines)
 
@@ -83,72 +71,17 @@ def _render_warnings(warnings: tuple[str, ...]) -> list[str]:
     return lines
 
 
-def select_digest_topics(
-    *,
-    insights: tuple[Insight, ...],
-    scoring: ScoringConfig,
-    thread_selection: ThreadSelection,
-    limit: int = 6,
-) -> tuple[RankedTopic, ...]:
-    scored_insights = sorted(
-        [(insight, score_insight(insight, scoring)) for insight in insights],
-        key=lambda item: (item[0].category, -item[1].total, item[0].title, item[0].source_id),
-    )
-    grouped: dict[tuple[str, str], list[tuple[Insight, object]]] = defaultdict(list)
-    for insight, breakdown in scored_insights:
-        grouped[(insight.category, insight.title.casefold())].append((insight, breakdown))
-
-    post_lookup = {ranked.post.id: ranked.post for ranked in thread_selection.ranked_posts}
-    topics: list[RankedTopic] = []
-    for entries in grouped.values():
-        best_insight, best_breakdown = sorted(
-            entries,
-            key=lambda item: (-item[1].total, item[0].title, item[0].source_id),
-        )[0]
-        source_post = post_lookup.get(best_insight.source_post_id)
-        source_title = source_post.title if source_post is not None else best_insight.title
-        source_url = source_post.url if source_post is not None else best_insight.source_permalink
-        source_subreddit = source_post.subreddit if source_post is not None else best_insight.subreddit
-        support_count = len({insight.source_post_id for insight, _ in entries})
-        topics.append(
-            RankedTopic(
-                topic_key="",
-                title=best_insight.title,
-                executive_summary=best_insight.summary,
-                relevance_for_user=best_insight.why_it_matters or best_insight.summary,
-                source_title=source_title,
-                source_url=source_url,
-                source_subreddit=source_subreddit,
-                impact_score=best_breakdown.total,
-                support_count=support_count,
-            )
-        )
-
-    ordered_topics = sorted(topics, key=lambda item: (-item.impact_score, item.title, item.source_url))[:limit]
-    return tuple(
-        RankedTopic(
-            topic_key=f"topic_{index}",
-            title=topic.title,
-            executive_summary=topic.executive_summary,
-            relevance_for_user=topic.relevance_for_user,
-            source_title=topic.source_title,
-            source_url=topic.source_url,
-            source_subreddit=topic.source_subreddit,
-            impact_score=topic.impact_score,
-            support_count=topic.support_count,
-        )
-        for index, topic in enumerate(ordered_topics, start=1)
-    )
-
-
-def _render_executive_summary(thread_selection: ThreadSelection, topics: tuple[RankedTopic, ...]) -> list[str]:
-    represented = tuple(dict.fromkeys(item.post.subreddit for item in thread_selection.ranked_posts))
-    top_topic = topics[0] if topics else None
+def _render_executive_summary(digest: DigestArtifact) -> list[str]:
     bullets = [
         "## Executive Summary",
-        *(f"- Picked {len(topics)} topics from {len(represented)} subreddit(s): {', '.join(f'r/{name}' for name in represented)}" for _ in [0] if represented),
-        *(f"- Highest-signal topic: {top_topic.title}" for _ in [0] if top_topic is not None),
-        f"- Total posts analyzed: {len(thread_selection.ranked_posts)}",
+        *(
+            f"- Picked {len(digest.topics)} topics from {len(digest.represented_subreddits)} subreddit(s): "
+            f"{', '.join(f'r/{name}' for name in digest.represented_subreddits)}"
+            for _ in [0]
+            if digest.represented_subreddits
+        ),
+        *(f"- Highest-signal topic: {digest.top_topic_title}" for _ in [0] if digest.top_topic_title is not None),
+        f"- Total posts analyzed: {digest.total_posts}",
         "",
     ]
     return bullets
@@ -181,35 +114,26 @@ def _render_picked_topics(
     return lines
 
 
-def _render_emerging_themes(scored_insights: list[tuple[Insight, object]]) -> list[str]:
+def _render_emerging_themes(digest: DigestArtifact) -> list[str]:
     lines = ["## Emerging Themes"]
-    tags = Counter(tag for insight, _ in scored_insights for tag in insight.tags)
-    if not tags:
+    if not digest.emerging_themes:
         lines.append("- No emerging themes today.")
         lines.append("")
         return lines
 
-    for tag, _count in tags.most_common(3):
-        evidence = ", ".join(insight.title for insight, _ in scored_insights if tag in insight.tags)
-        lines.append(f"- {tag.replace('-', ' ').title()}")
-        lines.append(f"  - Evidence: {evidence}")
+    for theme in digest.emerging_themes:
+        lines.append(f"- {theme.label}")
+        lines.append(f"  - Evidence: {theme.evidence}")
     lines.append("")
     return lines
 
 
-def _render_watch_next(
-    *,
-    watch_next: tuple[str, ...],
-    scored_insights: list[tuple[Insight, object]],
-) -> list[str]:
-    suggestions = list(watch_next)
-    if not suggestions:
-        suggestions = [insight.title for insight, _ in scored_insights if insight.novelty == "new"][:3]
-    if not suggestions:
+def _render_watch_next(digest: DigestArtifact) -> list[str]:
+    if not digest.watch_next:
         return []
 
     lines = ["## Watch Next"]
-    for item in suggestions:
+    for item in digest.watch_next:
         lines.append(f"- {item}")
     lines.append("")
     return lines

--- a/src/reddit_digest/pipeline.py
+++ b/src/reddit_digest/pipeline.py
@@ -21,6 +21,7 @@ from reddit_digest.extractors.openai_suggestions import generate_suggestions
 from reddit_digest.extractors.openai_suggestions import generate_topic_rewrites
 from reddit_digest.extractors.service import extract_insights
 from reddit_digest.outputs.google_sheets import GoogleSheetsExporter
+from reddit_digest.outputs.digest import build_digest_artifact
 from reddit_digest.outputs.markdown import render_markdown_digest
 from reddit_digest.outputs.markdown import select_digest_topics
 from reddit_digest.ranking.novelty import apply_novelty
@@ -155,6 +156,14 @@ class PipelineRunner:
                         item.topic_key: (item.executive_summary, item.relevance_for_user)
                         for item in rewrite_result.rewrites
                     }
+        digest = build_digest_artifact(
+            run_date=run_date,
+            insights=novelty.insights,
+            scoring=config.scoring,
+            thread_selection=thread_selection,
+            watch_next=suggestions,
+            topics=digest_topics,
+        )
         markdown = render_markdown_digest(
             run_date=run_date,
             insights=novelty.insights,
@@ -163,7 +172,7 @@ class PipelineRunner:
             reports_root=self.base_path / "reports",
             watch_next=suggestions,
             warnings=tuple(dict.fromkeys(markdown_warnings)),
-            topics=digest_topics,
+            digest=digest,
         )
         if topic_rewrites:
             render_markdown_digest(
@@ -172,8 +181,7 @@ class PipelineRunner:
                 scoring=config.scoring,
                 thread_selection=thread_selection,
                 reports_root=self.base_path / "reports",
-                watch_next=suggestions,
-                topics=digest_topics,
+                digest=digest,
                 topic_rewrites=topic_rewrites,
                 variant_suffix="llm",
             )
@@ -185,7 +193,7 @@ class PipelineRunner:
                     run_date=run_date,
                     posts=post_result.posts,
                     insights=novelty.insights,
-                    markdown_content=markdown.content,
+                    digest=digest,
                     scoring=config.scoring,
                     lookback_hours=config.subreddits.fetch.lookback_hours,
                     run_at=run_at,

--- a/tests/test_google_sheets.py
+++ b/tests/test_google_sheets.py
@@ -14,12 +14,12 @@ from reddit_digest.config import load_scoring_config
 from reddit_digest.extractors.service import extract_insights
 from reddit_digest.models.comment import Comment
 from reddit_digest.models.post import Post
+from reddit_digest.outputs.digest import build_digest_artifact
 from reddit_digest.outputs.google_sheets import DAILY_DIGEST_TAB
 from reddit_digest.outputs.google_sheets import GoogleSheetsExporter
 from reddit_digest.outputs.google_sheets import INSIGHTS_TAB
 from reddit_digest.outputs.google_sheets import RAW_POSTS_TAB
 from reddit_digest.outputs.google_sheets import load_google_sheets_credentials
-from reddit_digest.outputs.markdown import render_markdown_digest
 from reddit_digest.ranking.novelty import apply_novelty
 from reddit_digest.ranking.threads import select_threads
 
@@ -94,15 +94,14 @@ def build_inputs(sample_posts_payload: list[dict[str, object]], sample_comments_
         run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
         lookback_hours=24,
     )
-    markdown = render_markdown_digest(
+    digest = build_digest_artifact(
         run_date="2026-03-12",
         insights=novelty.insights,
         scoring=scoring,
         thread_selection=thread_selection,
-        reports_root=tmp_path / "reports",
         watch_next=("Monitor prompt-state snapshots",),
     )
-    return posts, novelty.insights, scoring, markdown.content
+    return posts, novelty.insights, scoring, digest
 
 
 def build_runtime(**overrides: object) -> RuntimeConfig:
@@ -128,13 +127,13 @@ def test_google_sheets_export_creates_expected_tabs(
 ) -> None:
     workbook = FakeWorkbook()
     exporter = GoogleSheetsExporter(workbook)
-    posts, insights, scoring, markdown_content = build_inputs(sample_posts_payload, sample_comments_payload, tmp_path)
+    posts, insights, scoring, digest = build_inputs(sample_posts_payload, sample_comments_payload, tmp_path)
 
     counts = exporter.export(
         run_date="2026-03-12",
         posts=posts,
         insights=insights,
-        markdown_content=markdown_content,
+        digest=digest,
         scoring=scoring,
         lookback_hours=24,
         run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
@@ -154,13 +153,13 @@ def test_google_sheets_export_is_idempotent_for_same_run_date(
 ) -> None:
     workbook = FakeWorkbook()
     exporter = GoogleSheetsExporter(workbook)
-    posts, insights, scoring, markdown_content = build_inputs(sample_posts_payload, sample_comments_payload, tmp_path)
+    posts, insights, scoring, digest = build_inputs(sample_posts_payload, sample_comments_payload, tmp_path)
 
     exporter.export(
         run_date="2026-03-12",
         posts=posts,
         insights=insights,
-        markdown_content=markdown_content,
+        digest=digest,
         scoring=scoring,
         lookback_hours=24,
         run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
@@ -169,7 +168,7 @@ def test_google_sheets_export_is_idempotent_for_same_run_date(
         run_date="2026-03-12",
         posts=posts,
         insights=insights,
-        markdown_content=markdown_content,
+        digest=digest,
         scoring=scoring,
         lookback_hours=24,
         run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
@@ -182,6 +181,70 @@ def test_google_sheets_export_is_idempotent_for_same_run_date(
     assert len(raw_rows) == len(posts)
     assert len(insight_rows) == len(insights)
     assert len(digest_rows) == 1
+
+
+def test_google_sheets_daily_digest_uses_structured_top_thread_not_collection_order(tmp_path: Path) -> None:
+    scoring = load_scoring_config(Path.cwd() / "config" / "scoring.yaml")
+    posts = (
+        Post.from_raw(
+            {
+                "id": "low",
+                "subreddit": "Codex",
+                "title": "Lower ranked first in collection order",
+                "author": "tester",
+                "score": 8,
+                "num_comments": 2,
+                "created_utc": 1_773_316_800,
+                "url": "https://reddit.com/r/Codex/comments/low",
+                "permalink": "/r/Codex/comments/low",
+                "selftext": "basic update",
+            }
+        ),
+        Post.from_raw(
+            {
+                "id": "high",
+                "subreddit": "ClaudeCode",
+                "title": "Higher ranked thread should win",
+                "author": "tester",
+                "score": 120,
+                "num_comments": 30,
+                "created_utc": 1_773_316_810,
+                "url": "https://reddit.com/r/ClaudeCode/comments/high",
+                "permalink": "/r/ClaudeCode/comments/high",
+                "selftext": "workflow deterministic testing prompt",
+            }
+        ),
+    )
+    insights = ()
+    thread_selection = select_threads(
+        posts,
+        scoring=scoring,
+        enabled_subreddits=("Codex", "ClaudeCode"),
+        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+        lookback_hours=24,
+    )
+    digest = build_digest_artifact(
+        run_date="2026-03-12",
+        insights=insights,
+        scoring=scoring,
+        thread_selection=thread_selection,
+        watch_next=("Monitor ranked thread selection",),
+    )
+    workbook = FakeWorkbook()
+
+    GoogleSheetsExporter(workbook).export(
+        run_date="2026-03-12",
+        posts=posts,
+        insights=insights,
+        digest=digest,
+        scoring=scoring,
+        lookback_hours=24,
+        run_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+    )
+
+    row = workbook.worksheet(DAILY_DIGEST_TAB).get_all_records()[0]
+    assert row["top_thread_title"] == "Higher ranked thread should win"
+    assert row["watch_next"] == "Monitor ranked thread selection"
 
 
 def test_load_google_sheets_credentials_prefers_service_account_json(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- add a typed digest artifact for selected topics, ranked threads, emerging themes, and watch-next items
- render markdown from that artifact and export the daily Sheets summary row from the same structure
- stop deriving Sheets summary data from rendered markdown or collection order and add regression coverage

## Testing
- PYTHONPATH=src /Users/wojciechwieczorek/Sii/reddit-ai-agents-digest/.venv/bin/pytest tests/test_google_sheets.py tests/test_markdown_output.py tests/test_reliability.py
- PYTHONPATH=src /Users/wojciechwieczorek/Sii/reddit-ai-agents-digest/.venv/bin/pytest

Closes #59