### PR TITLE
Use keyed upserts for Sheets exports

### DIFF
--- a/src/reddit_digest/outputs/google_sheets.py
+++ b/src/reddit_digest/outputs/google_sheets.py
@@ -39,10 +39,16 @@ class WorksheetLike(Protocol):
     def get_all_records(self) -> list[dict[str, Any]]:
         ...
 
-    def clear(self) -> None:
+    def get_all_values(self) -> list[list[Any]]:
         ...
 
-    def update(self, values: list[list[Any]]) -> None:
+    def update(self, range_name: str, values: list[list[Any]]) -> None:
+        ...
+
+    def append_rows(self, values: list[list[Any]]) -> None:
+        ...
+
+    def delete_rows(self, start_index: int, end_index: int | None = None) -> None:
         ...
 
 
@@ -88,9 +94,15 @@ class GoogleSheetsExporter:
         insight_rows = _build_insight_rows(insights, scoring, run_date=run_date)
         digest_row = _build_daily_digest_row(digest)
 
-        self._upsert_rows(RAW_POSTS_TAB, RAW_POST_HEADERS, run_date, raw_post_rows)
-        self._upsert_rows(INSIGHTS_TAB, INSIGHT_HEADERS, run_date, insight_rows)
-        self._upsert_rows(DAILY_DIGEST_TAB, DAILY_DIGEST_HEADERS, run_date, [digest_row])
+        self._upsert_rows(RAW_POSTS_TAB, RAW_POST_HEADERS, run_date, ("run_date", "post_id"), raw_post_rows)
+        self._upsert_rows(
+            INSIGHTS_TAB,
+            INSIGHT_HEADERS,
+            run_date,
+            ("run_date", "source_id", "category", "title"),
+            insight_rows,
+        )
+        self._upsert_rows(DAILY_DIGEST_TAB, DAILY_DIGEST_HEADERS, run_date, ("run_date",), [digest_row])
 
         LOGGER.info("Exported %s raw post rows to %s", len(raw_post_rows), RAW_POSTS_TAB)
         LOGGER.info("Exported %s insight rows to %s", len(insight_rows), INSIGHTS_TAB)
@@ -98,14 +110,73 @@ class GoogleSheetsExporter:
 
         return ExportCounts(raw_posts=len(raw_post_rows), insights=len(insight_rows), daily_digest=1)
 
-    def _upsert_rows(self, tab_name: str, headers: list[str], run_date: str, new_rows: list[dict[str, Any]]) -> None:
+    def _upsert_rows(
+        self,
+        tab_name: str,
+        headers: list[str],
+        run_date: str,
+        key_fields: tuple[str, ...],
+        new_rows: list[dict[str, Any]],
+    ) -> None:
         worksheet = self._ensure_worksheet(tab_name, cols=len(headers))
-        existing = worksheet.get_all_records()
-        preserved = [row for row in existing if row.get("run_date") != run_date]
-        merged_rows = preserved + new_rows
-        sheet_rows = [headers] + [[row.get(header, "") for header in headers] for row in merged_rows]
-        worksheet.clear()
-        worksheet.update(sheet_rows)
+        existing_values = worksheet.get_all_values()
+        if not existing_values:
+            worksheet.update(_row_range(1, len(headers)), [headers])
+            existing_records: list[dict[str, Any]] = []
+        else:
+            if existing_values[0] != headers:
+                worksheet.update(_row_range(1, len(headers)), [headers])
+            existing_records = worksheet.get_all_records()
+
+        existing_by_key = {
+            _row_key(row, key_fields): index
+            for index, row in enumerate(existing_records, start=2)
+            if _row_key(row, key_fields) is not None
+        }
+        new_by_key = {
+            _row_key(row, key_fields): row
+            for row in new_rows
+            if _row_key(row, key_fields) is not None
+        }
+
+        stale_rows = sorted(
+            [
+                row_index
+                for key, row_index in existing_by_key.items()
+                if key is not None
+                and key[0] == run_date
+                and key not in new_by_key
+            ],
+            reverse=True,
+        )
+        for row_index in stale_rows:
+            worksheet.delete_rows(row_index)
+
+        if stale_rows:
+            existing_records = worksheet.get_all_records()
+            existing_by_key = {
+                _row_key(row, key_fields): index
+                for index, row in enumerate(existing_records, start=2)
+                if _row_key(row, key_fields) is not None
+            }
+            surviving_existing = existing_by_key
+        else:
+            surviving_existing = existing_by_key
+
+        append_values: list[list[Any]] = []
+        for row in new_rows:
+            key = _row_key(row, key_fields)
+            if key is None:
+                continue
+            values = [[row.get(header, "") for header in headers]]
+            row_index = surviving_existing.get(key)
+            if row_index is None:
+                append_values.append(values[0])
+            else:
+                worksheet.update(_row_range(row_index, len(headers)), values)
+
+        if append_values:
+            worksheet.append_rows(append_values)
 
     def _ensure_worksheet(self, title: str, *, cols: int) -> WorksheetLike:
         try:
@@ -241,3 +312,26 @@ def _build_daily_digest_row(
         "top_testing_insight": digest.top_testing_insight,
         "watch_next": " | ".join(digest.watch_next[:3]),
     }
+
+
+def _row_key(row: dict[str, Any], key_fields: tuple[str, ...]) -> tuple[str, ...] | None:
+    values: list[str] = []
+    for field in key_fields:
+        value = row.get(field)
+        if value in (None, ""):
+            return None
+        values.append(str(value))
+    return tuple(values)
+
+
+def _row_range(row_index: int, column_count: int) -> str:
+    return f"A{row_index}:{_column_label(column_count)}{row_index}"
+
+
+def _column_label(column_index: int) -> str:
+    label = ""
+    current = column_index
+    while current > 0:
+        current, remainder = divmod(current - 1, 26)
+        label = chr(65 + remainder) + label
+    return label

--- a/tests/test_google_sheets.py
+++ b/tests/test_google_sheets.py
@@ -28,6 +28,10 @@ from reddit_digest.ranking.threads import select_threads
 class FakeWorksheet:
     title: str
     rows: list[list[Any]]
+    clear_calls: int = 0
+    update_calls: list[tuple[str, list[list[Any]]]] | None = None
+    append_calls: list[list[list[Any]]] | None = None
+    delete_calls: list[tuple[int, int | None]] | None = None
 
     def get_all_records(self) -> list[dict[str, Any]]:
         if not self.rows:
@@ -35,11 +39,38 @@ class FakeWorksheet:
         header = self.rows[0]
         return [dict(zip(header, row, strict=False)) for row in self.rows[1:]]
 
+    def get_all_values(self) -> list[list[Any]]:
+        return [list(row) for row in self.rows]
+
     def clear(self) -> None:
+        self.clear_calls += 1
         self.rows = []
 
-    def update(self, values: list[list[Any]]) -> None:
-        self.rows = values
+    def update(self, range_name: str, values: list[list[Any]]) -> None:
+        if self.update_calls is None:
+            self.update_calls = []
+        self.update_calls.append((range_name, values))
+        start_row = int(range_name.split(":")[0][1:])
+        while len(self.rows) < start_row:
+            self.rows.append([])
+        for offset, row in enumerate(values):
+            target_index = start_row - 1 + offset
+            while len(self.rows) <= target_index:
+                self.rows.append([])
+            self.rows[target_index] = row
+
+    def append_rows(self, values: list[list[Any]]) -> None:
+        if self.append_calls is None:
+            self.append_calls = []
+        self.append_calls.append(values)
+        self.rows.extend(values)
+
+    def delete_rows(self, start_index: int, end_index: int | None = None) -> None:
+        if self.delete_calls is None:
+            self.delete_calls = []
+        self.delete_calls.append((start_index, end_index))
+        end = start_index if end_index is None else end_index
+        del self.rows[start_index - 1 : end]
 
 
 class FakeWorkbook:
@@ -181,6 +212,60 @@ def test_google_sheets_export_is_idempotent_for_same_run_date(
     assert len(raw_rows) == len(posts)
     assert len(insight_rows) == len(insights)
     assert len(digest_rows) == 1
+    assert workbook.worksheet(RAW_POSTS_TAB).clear_calls == 0
+    assert workbook.worksheet(INSIGHTS_TAB).clear_calls == 0
+    assert workbook.worksheet(DAILY_DIGEST_TAB).clear_calls == 0
+
+
+def test_google_sheets_upsert_preserves_older_rows_and_removes_stale_same_date_rows() -> None:
+    workbook = FakeWorkbook()
+    exporter = GoogleSheetsExporter(workbook)
+    worksheet = workbook.add_worksheet(RAW_POSTS_TAB, rows=100, cols=10)
+    worksheet.rows = [
+        ["run_date", "post_id", "subreddit", "title", "url", "permalink", "score", "num_comments", "created_utc", "impact_score"],
+        ["2026-03-11", "old_1", "Codex", "Older row", "https://example.com/old", "/old", 10, 3, 123, 2.5],
+        ["2026-03-12", "stale", "Codex", "Stale row", "https://example.com/stale", "/stale", 5, 1, 124, 1.5],
+        ["2026-03-12", "keep", "ClaudeCode", "Outdated title", "https://example.com/keep", "/keep", 9, 4, 125, 3.5],
+    ]
+
+    exporter._upsert_rows(
+        RAW_POSTS_TAB,
+        ["run_date", "post_id", "subreddit", "title", "url", "permalink", "score", "num_comments", "created_utc", "impact_score"],
+        "2026-03-12",
+        ("run_date", "post_id"),
+        [
+            {
+                "run_date": "2026-03-12",
+                "post_id": "keep",
+                "subreddit": "ClaudeCode",
+                "title": "Updated title",
+                "url": "https://example.com/keep",
+                "permalink": "/keep",
+                "score": 11,
+                "num_comments": 5,
+                "created_utc": 125,
+                "impact_score": 4.1,
+            },
+            {
+                "run_date": "2026-03-12",
+                "post_id": "new_1",
+                "subreddit": "Vibecoding",
+                "title": "New row",
+                "url": "https://example.com/new",
+                "permalink": "/new",
+                "score": 7,
+                "num_comments": 2,
+                "created_utc": 126,
+                "impact_score": 2.2,
+            },
+        ],
+    )
+
+    records = worksheet.get_all_records()
+    assert [row["post_id"] for row in records] == ["old_1", "keep", "new_1"]
+    assert next(row for row in records if row["post_id"] == "keep")["title"] == "Updated title"
+    assert worksheet.clear_calls == 0
+    assert worksheet.delete_calls == [(3, None)]
 
 
 def test_google_sheets_daily_digest_uses_structured_top_thread_not_collection_order(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- replace destructive full-tab clears with keyed row updates, appends, and targeted stale-row deletes
- keep same-date reruns idempotent while preserving older rows on each tab
- extend Sheets tests to cover non-destructive updates and stale row removal

## Testing
- PYTHONPATH=src /Users/wojciechwieczorek/Sii/reddit-ai-agents-digest/.venv/bin/pytest tests/test_google_sheets.py
- PYTHONPATH=src /Users/wojciechwieczorek/Sii/reddit-ai-agents-digest/.venv/bin/pytest

Closes #60