### PR TITLE
Add repo invariants reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Primary outputs:
 - Keep run state in `data/state/`
 - Markdown output must be deterministic for the same input
 - Every new feature should include at least one test when reasonable
+- Treat [`docs/invariants.md`](docs/invariants.md) as the primary change-safety reference
 
 ## Digest rules
 Each daily digest should include:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ uv run pytest
 ## Documentation
 
 - [Architecture](docs/architecture.md)
+- [Repo invariants](docs/invariants.md)
 - [Operations](docs/operations.md)
 - [Digest format](docs/digest-format.md)
 - [GCP WIF setup](docs/gcp-wif-setup.md)
@@ -156,3 +157,6 @@ The project uses a `src/` layout and stores:
 
 Run state now also records OpenAI token usage totals plus Teams publish status
 for the completed run.
+
+Before changing pipeline behavior, ranking, or outputs, check the hard behavior
+guarantees in [`docs/invariants.md`](docs/invariants.md).

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -1,0 +1,42 @@
+# Repo Invariants
+
+Use this as the pre-change checklist for any pipeline, output, or docs change.
+
+## Source of record
+
+- `reports/daily/YYYY-MM-DD.md` is the canonical report for a run.
+- `reports/latest.md` is only the latest mirror of that deterministic report.
+- `reports/daily/YYYY-MM-DD.llm.md` and `reports/latest.llm.md` are advisory variants, not the source of record.
+
+## Deterministic behavior
+
+- The same input artifacts for the same run date must produce the same deterministic markdown.
+- Topic selection is deterministic and must stay grounded in collected Reddit posts and extracted insights.
+- Enabled subreddit filtering must remain correct; disabled subreddits must not influence ranked threads or picked topics.
+- Markdown structure must continue to follow the documented digest contract.
+
+## LLM constraints
+
+- OpenAI output is advisory only.
+- LLM rewrites may only rewrite prose for already selected topics.
+- LLM output must not change topic titles, source links, source subreddit attribution, support counts, or scores.
+- If OpenAI steps fail or quota is exhausted, the deterministic markdown still completes successfully.
+
+## Idempotency and reruns
+
+- Same-day reruns overwrite file outputs for that `run_date`; they do not create parallel copies.
+- `data/state/latest.json` mirrors the latest completed run state and should be replaced on rerun.
+- Google Sheets export must upsert by `run_date` and must not create duplicate rows for the same date.
+
+## Artifact ownership
+
+- Raw API payloads belong in `data/raw/`.
+- Normalized and derived JSON artifacts belong in `data/processed/`.
+- Run metadata belongs in `data/state/`.
+- Advisory delivery channels such as Teams must not replace local file artifacts as the authoritative output.
+
+## Failure behavior
+
+- Exceptions should not be silently swallowed.
+- Deterministic local artifacts should survive advisory-stage failures where documented.
+- Teams delivery remains best-effort and must not fail the deterministic pipeline.

--- a/tests/test_invariants_doc.py
+++ b/tests/test_invariants_doc.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_invariants_doc_is_linked_from_readme_and_agents() -> None:
+    readme = (Path.cwd() / "README.md").read_text()
+    agents = (Path.cwd() / "AGENTS.md").read_text()
+    invariants = (Path.cwd() / "docs" / "invariants.md").read_text()
+
+    assert "docs/invariants.md" in readme
+    assert "docs/invariants.md" in agents
+    assert "canonical report" in invariants
+    assert "OpenAI output is advisory only" in invariants
+    assert "Same-day reruns overwrite file outputs" in invariants
+    assert "must not create duplicate rows" in invariants


### PR DESCRIPTION
Summary:
- add a concise repo invariants doc covering deterministic, advisory, and idempotency guarantees
- link the invariants doc from README and AGENTS as the primary change-safety reference
- add a docs test to keep the links and key guarantees from drifting

Testing:
- PYTHONPATH=src /Users/wojciechwieczorek/Sii/reddit-ai-agents-digest/.venv/bin/pytest tests/test_invariants_doc.py tests/test_markdown_docs.py

Closes #65