### PR TITLE
Document persisted artifact schemas

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,8 @@ artifacts. The runtime flow is:
 
 Stage ownership and extension points are documented in
 [`docs/pipeline-stages.md`](pipeline-stages.md).
+Persisted field-level artifact contracts are documented in
+[`docs/artifact-schemas.md`](artifact-schemas.md).
 
 ## Code layout
 

--- a/docs/artifact-schemas.md
+++ b/docs/artifact-schemas.md
@@ -1,0 +1,221 @@
+# Artifact Schema Reference
+
+This page documents the persisted artifact families, their stable fields, and
+whether they are source-of-record or derived/advisory outputs.
+
+## Source-of-record summary
+
+- Source-of-record local outputs:
+  - `reports/daily/YYYY-MM-DD.md`
+  - `data/raw/**/*.json`
+  - `data/processed/posts/*.json`
+  - `data/processed/comments/*.json`
+  - `data/processed/insights/*.json`
+  - `data/state/*.json`
+- Derived deterministic outputs:
+  - Google Sheets rows derived from collected posts, insights, and digest summaries
+- Advisory outputs:
+  - `reports/daily/YYYY-MM-DD.llm.md`
+  - `data/processed/suggestions/*.json`
+  - `data/processed/topic_rewrites/*.json`
+  - Teams webhook payloads
+
+## Raw artifact families
+
+### `data/raw/posts/YYYY-MM-DD.json`
+
+- Type: object keyed by configured subreddit name
+- Per-subreddit fields:
+  - `sort_modes`: object keyed by listing mode such as `new` or `top`
+  - `selected`: array of shortlisted raw post payloads that passed filtering
+- Selected/raw post fields:
+  - `id`
+  - `subreddit`
+  - `title`
+  - `author`
+  - `score`
+  - `num_comments`
+  - `created_utc`
+  - `url`
+  - `permalink`
+  - `selftext`
+- Ownership: collection stage
+- Stability: shape should only change with an intentional collection contract change
+
+### `data/raw/comments/YYYY-MM-DD.json`
+
+- Type: object keyed by `post_id`
+- Value: array of raw comment payloads returned for that post before normalization filtering
+- Raw comment fields:
+  - `id`
+  - `post_id`
+  - `parent_id`
+  - `subreddit`
+  - `author`
+  - `body`
+  - `score`
+  - `created_utc`
+  - `permalink`
+- Ownership: collection stage
+- Stability: keyed by shortlisted post IDs for the run date
+
+## Processed deterministic artifact families
+
+### `data/processed/posts/YYYY-MM-DD.json`
+
+- Type: array of normalized `Post` records
+- Fields:
+  - `id`
+  - `subreddit`
+  - `title`
+  - `author`
+  - `score`
+  - `num_comments`
+  - `created_utc`
+  - `url`
+  - `permalink`
+  - `selftext`
+- Semantics: filtered shortlist used by downstream ranking and digest grounding
+
+### `data/processed/comments/YYYY-MM-DD.json`
+
+- Type: array of normalized `Comment` records
+- Fields:
+  - `id`
+  - `post_id`
+  - `parent_id`
+  - `subreddit`
+  - `author`
+  - `body`
+  - `score`
+  - `created_utc`
+  - `permalink`
+- Semantics: deleted/removed/empty comments are excluded before persistence
+
+### `data/processed/insights/YYYY-MM-DD.json`
+
+- Type: array of normalized `Insight` records
+- Fields:
+  - `category`
+  - `title`
+  - `summary`
+  - `tags`
+  - `evidence`
+  - `source_kind`
+  - `source_id`
+  - `source_permalink`
+  - `source_post_id`
+  - `subreddit`
+  - `novelty`
+  - `why_it_matters`
+- Semantics:
+  - `source_kind` is `post` or `comment`
+  - `novelty` is persisted after novelty comparison and is typically `new` or `ongoing`
+  - `why_it_matters` is the deterministic relevance text used by the canonical digest
+
+## Advisory processed artifact families
+
+### `data/processed/suggestions/YYYY-MM-DD.json`
+
+- Type: array of advisory `Suggestion` records
+- Fields:
+  - `category`
+  - `title`
+  - `rationale`
+- Semantics:
+  - `category` is `content` or `source`
+  - derived only from the day’s collected findings
+  - used for `Watch Next` and future monitoring ideas, not same-day topic selection
+
+### `data/processed/topic_rewrites/YYYY-MM-DD.json`
+
+- Type: array of advisory topic rewrite records
+- Fields:
+  - `topic_key`
+  - `executive_summary`
+  - `relevance_for_user`
+- Semantics:
+  - must exactly cover the deterministic topic set for that run
+  - may rewrite prose only
+  - may not change titles, links, source subreddits, scores, or counts
+
+## Run state
+
+### `data/state/YYYY-MM-DD.json` and `data/state/latest.json`
+
+- Type: single object
+- Fields:
+  - `run_date`
+  - `completed_at`
+  - `raw_posts_path`
+  - `raw_comments_path`
+  - `insights_path`
+  - `report_path`
+  - `sheets_exported`
+  - `teams_published`
+  - `teams_error`
+  - `openai_usage`
+- Nested `openai_usage` fields:
+  - `total_calls`
+  - `input_tokens`
+  - `output_tokens`
+  - `total_tokens`
+  - `operations`
+- Nested `operations` item fields:
+  - `operation`
+  - `calls`
+  - `input_tokens`
+  - `output_tokens`
+  - `total_tokens`
+- Semantics:
+  - `report_path` always points to the deterministic markdown
+  - `latest.json` mirrors the latest completed run and is replaced on rerun
+
+## Google Sheets tabs
+
+### `Raw_Posts`
+
+- Columns:
+  - `run_date`
+  - `post_id`
+  - `subreddit`
+  - `title`
+  - `url`
+  - `permalink`
+  - `score`
+  - `num_comments`
+  - `created_utc`
+  - `impact_score`
+- Key semantics: upserted by `run_date` plus `post_id`
+
+### `Insights`
+
+- Columns:
+  - `run_date`
+  - `category`
+  - `title`
+  - `subreddit`
+  - `source_kind`
+  - `source_id`
+  - `source_post_id`
+  - `source_permalink`
+  - `novelty`
+  - `tags`
+  - `impact_score`
+  - `why_it_matters`
+- Key semantics: upserted by `run_date` plus `source_id`
+
+### `Daily_Digest`
+
+- Columns:
+  - `run_date`
+  - `total_posts`
+  - `total_insights`
+  - `top_thread_title`
+  - `top_thread_url`
+  - `top_tool`
+  - `top_approach`
+  - `top_guide`
+  - `top_testing_insight`
+  - `watch_next`
+- Key semantics: one summary row per `run_date`

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -66,6 +66,9 @@ uv run reddit-digest run-daily --date 2026-03-12
 
 ## Output locations
 
+Schema details for these artifact families live in
+[`docs/artifact-schemas.md`](artifact-schemas.md).
+
 - Raw posts: `data/raw/posts/YYYY-MM-DD.json`
 - Raw comments: `data/raw/comments/YYYY-MM-DD.json`
 - Processed posts: `data/processed/posts/YYYY-MM-DD.json`

--- a/tests/test_artifact_schema_doc.py
+++ b/tests/test_artifact_schema_doc.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_artifact_schema_doc_covers_persisted_families_and_links() -> None:
+    operations = (Path.cwd() / "docs" / "operations.md").read_text()
+    architecture = (Path.cwd() / "docs" / "architecture.md").read_text()
+    document = (Path.cwd() / "docs" / "artifact-schemas.md").read_text()
+
+    assert "docs/artifact-schemas.md" in operations
+    assert "docs/artifact-schemas.md" in architecture
+    assert "data/raw/posts/YYYY-MM-DD.json" in document
+    assert "data/raw/comments/YYYY-MM-DD.json" in document
+    assert "data/processed/insights/YYYY-MM-DD.json" in document
+    assert "data/processed/suggestions/YYYY-MM-DD.json" in document
+    assert "data/processed/topic_rewrites/YYYY-MM-DD.json" in document
+    assert "data/state/YYYY-MM-DD.json" in document
+    assert "Raw_Posts" in document
+    assert "Insights" in document
+    assert "Daily_Digest" in document
+    assert "Source-of-record local outputs" in document
+    assert "Advisory outputs" in document


### PR DESCRIPTION
Summary:
- add a schema reference doc for raw, processed, advisory, run-state, and Google Sheets artifacts
- link the schema reference from operations and architecture
- add a docs test to keep the persisted artifact coverage and links in sync

Testing:
- PYTHONPATH=src /Users/wojciechwieczorek/Sii/reddit-ai-agents-digest/.venv/bin/pytest tests/test_artifact_schema_doc.py tests/test_pipeline_stage_docs.py tests/test_markdown_docs.py

Closes #67