### PR TITLE
Add local launchd runner for AI digest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 gha-creds-*.json
 .agents/
 .desloppify/
+*.log
 data/raw/*
 data/processed/*
 data/state/*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test lint run preflight run-markdown
+.PHONY: install test lint run preflight run-markdown run-ai
 
 install:
 	uv sync
@@ -18,3 +18,7 @@ preflight:
 run-markdown:
 	uv run reddit-digest preflight --base-path . --skip-sheets --markdown-only
 	uv run reddit-digest run-daily --base-path . --skip-sheets --markdown-only
+
+run-ai:
+	uv run reddit-digest preflight --base-path . --skip-sheets
+	uv run reddit-digest run-daily --base-path . --skip-sheets

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Run the markdown-only digest locally:
 make run-markdown
 ```
 
+Run the AI-enhanced digest locally (no Sheets export):
+
+```bash
+make run-ai
+```
+
 The canonical setup for Codex automation is
 `.codex/environments/environment.toml`, which runs
 `scripts/configure_codex_worktree_env.sh` during environment setup. That script
@@ -66,11 +72,13 @@ the CLI falls back to the primary worktree's `.env`.
 Required environment variables for local markdown-only runs:
 - `REDDIT_USER_AGENT`
 
+Additional required environment variable for local AI-enhanced runs:
+- `OPENAI_API_KEY`
+
 Additional environment variables for local Sheets export:
 - `GOOGLE_SHEETS_SPREADSHEET_ID`
 
 Optional runtime environment variables:
-- `OPENAI_API_KEY`
 - `OPENAI_MODEL` (defaults to `gpt-5-mini`)
 - `TEAMS_WEBHOOK_URL`
 
@@ -112,6 +120,10 @@ uv run reddit-digest preflight --base-path . --skip-sheets --markdown-only
 direct CLI markdown run-daily command, and still forces deterministic
 markdown-only execution even when `OPENAI_API_KEY` is present.
 
+`make run-ai` runs direct CLI commands without `--markdown-only`, still with
+`--skip-sheets`, so local execution keeps deterministic topic selection while
+enabling AI-enhanced outputs.
+
 If `TEAMS_WEBHOOK_URL` is set, the pipeline also posts an advisory Teams summary
 after local report generation. Teams delivery is best-effort and does not
 replace the deterministic markdown as the source of record.
@@ -128,7 +140,8 @@ The supported automated execution path is now a GitHub Actions `self-hosted`
 runner or a direct local run on the same machine. GitHub-hosted runners are not
 supported for live Reddit collection because Reddit blocks the public JSON
 requests from those runner IPs. The canonical markdown-only command is
-`make run-markdown`.
+`make run-markdown`; the canonical AI-enhanced local no-Sheets command is
+`make run-ai`.
 
 The self-hosted GitHub Actions workflow runs the markdown pipeline only with
 `--skip-sheets --markdown-only`, so it does not require Google credentials.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -14,6 +14,9 @@ CLI falls back to the primary worktree's `.env`.
 Required environment variables for local markdown-only runs:
 - `REDDIT_USER_AGENT`
 
+Additional required environment variable for local AI-enhanced runs:
+- `OPENAI_API_KEY`
+
 Additional environment variables for the full local pipeline:
 - `GOOGLE_SHEETS_SPREADSHEET_ID`
 
@@ -27,7 +30,6 @@ Local development differs from CI:
 - `GOOGLE_SERVICE_ACCOUNT_JSON` is only a local fallback when ADC is not available.
 
 Optional environment variables:
-- `OPENAI_API_KEY`
 - `OPENAI_MODEL`
 - `TEAMS_WEBHOOK_URL`
 - `INCLUDE_SECONDARY_SUBREDDITS`
@@ -75,6 +77,19 @@ make run-markdown
 1. `uv run reddit-digest preflight --base-path . --skip-sheets --markdown-only`
 2. `uv run reddit-digest run-daily --base-path . --skip-sheets --markdown-only`
 
+Run the AI-enhanced no-Sheets pipeline:
+
+```bash
+make run-ai
+```
+
+`make run-ai` runs direct CLI commands only:
+1. `uv run reddit-digest preflight --base-path . --skip-sheets`
+2. `uv run reddit-digest run-daily --base-path . --skip-sheets`
+
+Use `make run-markdown` for deterministic local markdown-only execution.
+Use `make run-ai` for local AI-enhanced execution without Google Sheets export.
+
 The Codex setup script `scripts/configure_codex_worktree_env.sh` remains the
 bootstrap entrypoint for Codex environment setup, including `.env` worktree
 seeding, `uv` resolution, and preflight validation.
@@ -94,6 +109,35 @@ Run the full pipeline including advisory OpenAI stages and Sheets export:
 ```bash
 uv run reddit-digest run-daily --date 2026-03-12
 ```
+
+## launchd local scheduler
+
+User LaunchAgent template:
+- `ops/launchd/com.vojow.reddit-ai-agents-digest.daily.plist`
+
+This LaunchAgent runs daily at `09:00` local time and executes:
+- `scripts/run_ai_launchd.sh`
+- which updates `main` with `git fetch origin main` + `git pull --ff-only origin main`
+- then runs `make run-ai`
+
+Install / reload / trigger:
+
+```bash
+mkdir -p ~/Library/LaunchAgents
+mkdir -p ~/Library/Logs/reddit-ai-agents-digest
+cp ops/launchd/com.vojow.reddit-ai-agents-digest.daily.plist ~/Library/LaunchAgents/
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.vojow.reddit-ai-agents-digest.daily.plist || true
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.vojow.reddit-ai-agents-digest.daily.plist
+launchctl kickstart -k gui/$(id -u)/com.vojow.reddit-ai-agents-digest.daily
+```
+
+Log files:
+- `/Users/wojciechwieczorek/Library/Logs/reddit-ai-agents-digest/daily.out.log`
+- `/Users/wojciechwieczorek/Library/Logs/reddit-ai-agents-digest/daily.err.log`
+
+Failure behavior:
+- `scripts/run_ai_launchd.sh` exits with deterministic `RUN_AI_LAUNCHD FAIL: ...` lines
+- on failure it also triggers a macOS notification via `osascript`
 
 ## Output locations
 

--- a/ops/launchd/com.vojow.reddit-ai-agents-digest.daily.plist
+++ b/ops/launchd/com.vojow.reddit-ai-agents-digest.daily.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.vojow.reddit-ai-agents-digest.daily</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/wojciechwieczorek/Sii/reddit-ai-agents-digest/scripts/run_ai_launchd.sh</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/wojciechwieczorek/Sii/reddit-ai-agents-digest</string>
+
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>9</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+
+  <key>StandardOutPath</key>
+  <string>/Users/wojciechwieczorek/Library/Logs/reddit-ai-agents-digest/daily.out.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/wojciechwieczorek/Library/Logs/reddit-ai-agents-digest/daily.err.log</string>
+</dict>
+</plist>

--- a/scripts/run_ai_launchd.sh
+++ b/scripts/run_ai_launchd.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+export GIT_TERMINAL_PROMPT=0
+
+notify_failure() {
+  local message="$1"
+  osascript -e "display notification \"${message}\" with title \"reddit-ai-agents-digest\"" >/dev/null 2>&1 || true
+}
+
+fail() {
+  local reason="$1"
+  printf "RUN_AI_LAUNCHD FAIL: %s\n" "${reason}"
+  notify_failure "${reason}"
+  exit 1
+}
+
+printf "RUN_AI_LAUNCHD START: repo=%s\n" "${REPO_ROOT}"
+
+if ! branch="$(git -C "${REPO_ROOT}" rev-parse --abbrev-ref HEAD 2>/dev/null)"; then
+  fail "unable to determine current branch"
+fi
+if [[ "${branch}" != "main" ]]; then
+  fail "expected main branch, got ${branch}"
+fi
+
+if [[ -n "$(git -C "${REPO_ROOT}" status --porcelain)" ]]; then
+  fail "worktree is dirty"
+fi
+
+if ! git -C "${REPO_ROOT}" fetch origin main; then
+  fail "git fetch origin main failed"
+fi
+if ! git -C "${REPO_ROOT}" pull --ff-only origin main; then
+  fail "git pull --ff-only origin main failed"
+fi
+if ! make -C "${REPO_ROOT}" run-ai; then
+  fail "make run-ai failed"
+fi
+
+printf "RUN_AI_LAUNCHD OK: make run-ai completed\n"

--- a/tests/test_automation_helper.py
+++ b/tests/test_automation_helper.py
@@ -95,8 +95,14 @@ def test_makefile_markdown_targets_use_direct_cli_commands() -> None:
     assert not Path("scripts/run_markdown_with_env.sh").exists()
     assert "preflight:" in content
     assert "run-markdown:" in content
+    assert "run-ai:" in content
+    assert ".PHONY: install test lint run preflight run-markdown run-ai" in content
     assert "uv run reddit-digest preflight --base-path . --skip-sheets --markdown-only" in content
     assert "uv run reddit-digest run-daily --base-path . --skip-sheets --markdown-only" in content
+    assert "uv run reddit-digest preflight --base-path . --skip-sheets" in content
+    assert "uv run reddit-digest run-daily --base-path . --skip-sheets" in content
+    run_ai_block = content.split("run-ai:", maxsplit=1)[1]
+    assert "--markdown-only" not in run_ai_block
     assert "run_markdown_with_env.sh" not in content
 
 

--- a/tests/test_launchd_plist.py
+++ b/tests/test_launchd_plist.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+
+
+def test_launchd_daily_plist_has_expected_schedule_and_paths() -> None:
+    plist_path = Path("ops/launchd/com.vojow.reddit-ai-agents-digest.daily.plist")
+    assert plist_path.exists()
+
+    payload = plistlib.loads(plist_path.read_bytes())
+
+    assert payload["Label"] == "com.vojow.reddit-ai-agents-digest.daily"
+    assert payload["ProgramArguments"] == [
+        "/bin/bash",
+        "/Users/wojciechwieczorek/Sii/reddit-ai-agents-digest/scripts/run_ai_launchd.sh",
+    ]
+    assert payload["WorkingDirectory"] == "/Users/wojciechwieczorek/Sii/reddit-ai-agents-digest"
+    assert payload["RunAtLoad"] is False
+    assert payload["StartCalendarInterval"] == {"Hour": 9, "Minute": 0}
+    assert (
+        payload["StandardOutPath"]
+        == "/Users/wojciechwieczorek/Library/Logs/reddit-ai-agents-digest/daily.out.log"
+    )
+    assert (
+        payload["StandardErrorPath"]
+        == "/Users/wojciechwieczorek/Library/Logs/reddit-ai-agents-digest/daily.err.log"
+    )

--- a/tests/test_markdown_docs.py
+++ b/tests/test_markdown_docs.py
@@ -12,9 +12,22 @@ def test_docs_describe_dual_markdown_outputs() -> None:
 
     assert "reports/daily/YYYY-MM-DD.llm.md" in readme
     assert "source of record" in readme
+    assert "make run-ai" in readme
+    assert "AI-enhanced digest locally (no Sheets export)" in readme
+    assert "Additional required environment variable for local AI-enhanced runs" in readme
+    assert "OPENAI_API_KEY" in readme
     assert ".codex/environments/environment.toml" in readme
     assert "scripts/configure_codex_worktree_env.sh" in readme
     assert "reports/latest.llm.md" in operations
+    assert "make run-ai" in operations
+    assert "ops/launchd/com.vojow.reddit-ai-agents-digest.daily.plist" in operations
+    assert "launchctl bootstrap gui/$(id -u)" in operations
+    assert "launchctl bootout gui/$(id -u)" in operations
+    assert "launchctl kickstart -k gui/$(id -u)/com.vojow.reddit-ai-agents-digest.daily" in operations
+    assert "mkdir -p ~/Library/Logs/reddit-ai-agents-digest" in operations
+    assert "/Users/wojciechwieczorek/Library/Logs/reddit-ai-agents-digest/daily.out.log" in operations
+    assert "/Users/wojciechwieczorek/Library/Logs/reddit-ai-agents-digest/daily.err.log" in operations
+    assert "OPENAI_API_KEY" in operations
     assert ".codex/environments/environment.toml" in operations
     assert "scripts/configure_codex_worktree_env.sh" in operations
     assert "data/processed/topic_rewrites/YYYY-MM-DD.json" in operations

--- a/tests/test_run_ai_launchd.py
+++ b/tests/test_run_ai_launchd.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def _copy_run_ai_launchd_script(repo_root: Path) -> Path:
+    source = Path.cwd() / "scripts" / "run_ai_launchd.sh"
+    target = repo_root / "scripts" / "run_ai_launchd.sh"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(source.read_text())
+    target.chmod(0o755)
+    return target
+
+
+def _write_fake_git(bin_dir: Path) -> None:
+    git_path = bin_dir / "git"
+    git_path.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "printf '%q ' \"$@\" >> \"$FAKE_GIT_LOG\"\n"
+        "printf '\\n' >> \"$FAKE_GIT_LOG\"\n"
+        "if [[ \"${1:-}\" == \"-C\" ]]; then\n"
+        "  shift 2\n"
+        "fi\n"
+        "case \"${1:-}\" in\n"
+        "  rev-parse)\n"
+        "    printf '%s\\n' \"${FAKE_GIT_BRANCH:-main}\"\n"
+        "    ;;\n"
+        "  status)\n"
+        "    if [[ \"${FAKE_GIT_DIRTY:-0}\" == \"1\" ]]; then\n"
+        "      printf ' M README.md\\n'\n"
+        "    fi\n"
+        "    ;;\n"
+        "  fetch)\n"
+        "    if [[ \"${FAKE_GIT_FAIL_FETCH:-0}\" == \"1\" ]]; then\n"
+        "      exit 21\n"
+        "    fi\n"
+        "    ;;\n"
+        "  pull)\n"
+        "    if [[ \"${FAKE_GIT_FAIL_PULL:-0}\" == \"1\" ]]; then\n"
+        "      exit 22\n"
+        "    fi\n"
+        "    ;;\n"
+        "esac\n"
+    )
+    git_path.chmod(0o755)
+
+
+def _write_fake_make(bin_dir: Path) -> None:
+    make_path = bin_dir / "make"
+    make_path.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "printf '%q ' \"$@\" >> \"$FAKE_MAKE_LOG\"\n"
+        "printf '\\n' >> \"$FAKE_MAKE_LOG\"\n"
+        "if [[ \"${FAKE_MAKE_FAIL:-0}\" == \"1\" ]]; then\n"
+        "  exit 31\n"
+        "fi\n"
+    )
+    make_path.chmod(0o755)
+
+
+def _write_fake_osascript(bin_dir: Path) -> None:
+    osascript_path = bin_dir / "osascript"
+    osascript_path.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "printf '%q ' \"$@\" >> \"$FAKE_OSASCRIPT_LOG\"\n"
+        "printf '\\n' >> \"$FAKE_OSASCRIPT_LOG\"\n"
+    )
+    osascript_path.chmod(0o755)
+
+
+def _run_launchd_wrapper(script_path: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["/bin/bash", str(script_path)],
+        cwd=script_path.parent.parent,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _base_env(tmp_path: Path, fake_bin: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["FAKE_GIT_LOG"] = str(tmp_path / "git.log")
+    env["FAKE_MAKE_LOG"] = str(tmp_path / "make.log")
+    env["FAKE_OSASCRIPT_LOG"] = str(tmp_path / "osascript.log")
+    return env
+
+
+def test_run_ai_launchd_rejects_non_main_branch(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    script_path = _copy_run_ai_launchd_script(repo_root)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_fake_git(fake_bin)
+    _write_fake_make(fake_bin)
+    _write_fake_osascript(fake_bin)
+
+    env = _base_env(tmp_path, fake_bin)
+    env["FAKE_GIT_BRANCH"] = "feature/testing"
+
+    result = _run_launchd_wrapper(script_path, env)
+
+    assert result.returncode == 1
+    assert "RUN_AI_LAUNCHD FAIL: expected main branch, got feature/testing" in result.stdout
+    osascript_log = Path(env["FAKE_OSASCRIPT_LOG"]).read_text()
+    assert "reddit-ai-agents-digest" in osascript_log
+
+
+def test_run_ai_launchd_rejects_dirty_repo(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    script_path = _copy_run_ai_launchd_script(repo_root)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_fake_git(fake_bin)
+    _write_fake_make(fake_bin)
+    _write_fake_osascript(fake_bin)
+
+    env = _base_env(tmp_path, fake_bin)
+    env["FAKE_GIT_BRANCH"] = "main"
+    env["FAKE_GIT_DIRTY"] = "1"
+
+    result = _run_launchd_wrapper(script_path, env)
+
+    assert result.returncode == 1
+    assert "RUN_AI_LAUNCHD FAIL: worktree is dirty" in result.stdout
+    osascript_log = Path(env["FAKE_OSASCRIPT_LOG"]).read_text()
+    assert "reddit-ai-agents-digest" in osascript_log
+
+
+def test_run_ai_launchd_fetches_pulls_and_runs_make_run_ai(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    script_path = _copy_run_ai_launchd_script(repo_root)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_fake_git(fake_bin)
+    _write_fake_make(fake_bin)
+    _write_fake_osascript(fake_bin)
+
+    env = _base_env(tmp_path, fake_bin)
+    env["FAKE_GIT_BRANCH"] = "main"
+
+    result = _run_launchd_wrapper(script_path, env)
+
+    assert result.returncode == 0, result.stdout
+    assert "RUN_AI_LAUNCHD OK: make run-ai completed" in result.stdout
+    git_log = Path(env["FAKE_GIT_LOG"]).read_text()
+    make_log = Path(env["FAKE_MAKE_LOG"]).read_text()
+    assert "fetch origin main" in git_log
+    assert "pull --ff-only origin main" in git_log
+    assert "run-ai" in make_log
+
+
+def test_run_ai_launchd_triggers_osascript_on_make_failure(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    script_path = _copy_run_ai_launchd_script(repo_root)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_fake_git(fake_bin)
+    _write_fake_make(fake_bin)
+    _write_fake_osascript(fake_bin)
+
+    env = _base_env(tmp_path, fake_bin)
+    env["FAKE_GIT_BRANCH"] = "main"
+    env["FAKE_MAKE_FAIL"] = "1"
+
+    result = _run_launchd_wrapper(script_path, env)
+
+    assert result.returncode == 1
+    assert "RUN_AI_LAUNCHD FAIL: make run-ai failed" in result.stdout
+    osascript_log = Path(env["FAKE_OSASCRIPT_LOG"]).read_text()
+    assert "reddit-ai-agents-digest" in osascript_log


### PR DESCRIPTION
## Summary
- add a local AI-enhanced launchd runner and LaunchAgent template
- add `make run-ai` and document the local scheduler flow
- cover the wrapper, plist, docs, and make targets with tests

## Testing
- `$HOME/.local/bin/uv run pytest -q`